### PR TITLE
feat(contracts): define vision identify and nutrition estimate schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-*.json
+data/Food/FoodData_Central_sr_legacy_food_json_2018-04.json
+data/Food/FoodData_Central_foundation_food_json_2025-12-18.json
 .docx_work/
 Environment/.env

--- a/contracts/nutrition_estimate.json
+++ b/contracts/nutrition_estimate.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qima/contracts/nutrition_estimate.json",
+  "title": "Qima Nutrition Estimate Response",
+  "description": "Backend-owned response contract for /nutrition/estimate.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "matched_dish",
+    "nutrients",
+    "confidence",
+    "source"
+  ],
+  "properties": {
+    "matched_dish": {
+      "type": "object",
+      "description": "Backend-selected normalized food or dish match used for nutrient estimation.",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "serving_basis": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Serving assumption used for the nutrient estimate when available."
+        }
+      }
+    },
+    "nutrients": {
+      "type": "object",
+      "description": "Normalized nutrient payload owned by the backend.",
+      "additionalProperties": false,
+      "required": [
+        "calories_kcal",
+        "protein_g",
+        "carbohydrates_g",
+        "fat_g"
+      ],
+      "properties": {
+        "calories_kcal": {
+          "type": "number",
+          "minimum": 0
+        },
+        "protein_g": {
+          "type": "number",
+          "minimum": 0
+        },
+        "carbohydrates_g": {
+          "type": "number",
+          "minimum": 0
+        },
+        "fat_g": {
+          "type": "number",
+          "minimum": 0
+        },
+        "fiber_g": {
+          "type": "number",
+          "minimum": 0
+        },
+        "sugar_g": {
+          "type": "number",
+          "minimum": 0
+        },
+        "sodium_mg": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Overall backend confidence for the nutrient estimate."
+    },
+    "source": {
+      "type": "object",
+      "description": "Normalized source metadata for the nutrition data selected by the backend.",
+      "additionalProperties": false,
+      "required": [
+        "dataset",
+        "source_type"
+      ],
+      "properties": {
+        "dataset": {
+          "type": "string",
+          "enum": [
+            "nutrition.xlsx",
+            "Egyptian Food.csv",
+            "FoodData Central Foundation",
+            "FoodData Central SR Legacy"
+          ]
+        },
+        "source_type": {
+          "type": "string",
+          "const": "nutrition_dataset"
+        }
+      }
+    }
+  }
+}

--- a/contracts/vision_identify.json
+++ b/contracts/vision_identify.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qima/contracts/vision_identify.json",
+  "title": "Qima Vision Identify Response",
+  "description": "Backend-owned response contract for /vision/identify.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "image_id",
+    "dish_candidates",
+    "ingredients",
+    "confidence",
+    "source"
+  ],
+  "properties": {
+    "image_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Backend-assigned identifier for the uploaded image."
+    },
+    "dish_candidates": {
+      "type": "array",
+      "description": "Ordered candidate dishes recognized from the image.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "confidence"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      }
+    },
+    "ingredients": {
+      "type": "array",
+      "description": "Structured ingredient candidates extracted from the image.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "confidence"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Overall backend confidence for the identification result."
+    },
+    "source": {
+      "type": "object",
+      "description": "Normalized source metadata for the vision provider used by the backend.",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model",
+        "source_type"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "const": "gemini"
+        },
+        "model": {
+          "type": "string",
+          "const": "gemini-2.5-flash"
+        },
+        "source_type": {
+          "type": "string",
+          "const": "vision_model"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Defines backend-owned JSON schemas for `/vision/identify` and `/nutrition/estimate`.

### Included
- `contracts/vision_identify.json`
- `contracts/nutrition_estimate.json`

### Schema coverage
- `/vision/identify`: `dish_candidates`, `ingredients`, `confidence`, `image_id`, `source`
- `/nutrition/estimate`: matched dish, nutrients, confidence, source

### Outcome
Aligns the contracts with the architecture baseline and formalizes the vision/nutrition response structure.