### PR TITLE
feat(contracts): define recipe suggest and discuss schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.json
+!contracts/
+!contracts/*.json
 .docx_work/
 Environment/.env

--- a/contracts/recipes_discuss.json
+++ b/contracts/recipes_discuss.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qima/contracts/recipes_discuss.json",
+  "title": "Qima Recipe Discuss Response",
+  "description": "Backend-owned response contract for /recipes/discuss.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "answer",
+    "grounded_references",
+    "safety_flags"
+  ],
+  "properties": {
+    "answer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Grounded backend answer derived from retrieved recipe references."
+    },
+    "grounded_references": {
+      "type": "array",
+      "description": "Recipe corpus references that support the answer.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "recipe_id",
+          "title",
+          "reference_type",
+          "reference_text"
+        ],
+        "properties": {
+          "recipe_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reference_type": {
+            "type": "string",
+            "enum": [
+              "ingredient",
+              "instruction",
+              "metadata"
+            ]
+          },
+          "reference_text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Retrieved recipe text fragment used as grounding."
+          }
+        }
+      }
+    },
+    "safety_flags": {
+      "type": "array",
+      "description": "Safety-related flags raised from recipe content or backend rules.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "severity"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "allergen_risk",
+              "undercooked_risk",
+              "cross_contamination_risk",
+              "diet_conflict",
+              "no_known_risk"
+            ]
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "details": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/recipes_suggest.json
+++ b/contracts/recipes_suggest.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qima/contracts/recipes_suggest.json",
+  "title": "Qima Recipe Suggest Response",
+  "description": "Backend-owned response contract for /recipes/suggest.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "recipes",
+    "source"
+  ],
+  "properties": {
+    "recipes": {
+      "type": "array",
+      "description": "Retrieved recipe candidates ranked by backend match logic.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "recipe_id",
+          "title",
+          "match_score",
+          "missing_ingredients",
+          "warnings"
+        ],
+        "properties": {
+          "recipe_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Stable identifier from the recipe corpus."
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "match_score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Backend-computed retrieval score for the recipe candidate."
+          },
+          "missing_ingredients": {
+            "type": "array",
+            "description": "Ingredients required by the recipe but not present in the user context.",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "warnings": {
+            "type": "array",
+            "description": "Grounded warnings derived from retrieved recipe content or backend rules.",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "description": "Normalized source metadata for the retrieval corpus used by the backend.",
+      "additionalProperties": false,
+      "required": [
+        "dataset",
+        "retrieval_mode",
+        "source_type"
+      ],
+      "properties": {
+        "dataset": {
+          "type": "string",
+          "const": "13k-recipes.csv"
+        },
+        "retrieval_mode": {
+          "type": "string",
+          "const": "retrieval_first"
+        },
+        "source_type": {
+          "type": "string",
+          "const": "recipe_corpus"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Defines grounded backend-owned schemas for `/recipes/suggest` and `/recipes/discuss`.

### Included
- `contracts/recipes_suggest.json`
- `contracts/recipes_discuss.json`

### Schema coverage
- `/recipes/suggest`: `recipes`, `match_score`, `missing_ingredients`, `warnings`, `source`
- `/recipes/discuss`: `answer`, `grounded_references`, `safety_flags`

### Outcome
Aligns the recipe layer with the retrieval-first architecture and avoids free-form generation fields.