### PR TITLE
feat(contracts): add v1 API contract schemas for chat, recipes, visio…

### DIFF
--- a/contracts/v1/README.md
+++ b/contracts/v1/README.md
@@ -1,0 +1,181 @@
+# API Contracts — v1
+
+This directory defines the **public, client-facing API contracts** for the Qima backend.
+It is the single source of truth for:
+- request and response schemas
+- error handling structure
+- versioning rules
+- behavioral guarantees and constraints
+
+Clients (Flutter) must rely **only** on what is defined here.
+The backend may change internally (providers, models, data sources, logic), but **these contracts must remain stable within a version**.
+
+---
+
+## Contract Scope
+
+All contracts in this directory follow a consistent structure:
+- `endpoint` (path)
+- `method`
+- `request`
+- `responses`
+
+Each contract fully defines:
+- valid inputs
+- successful responses
+- error responses
+
+No behavior outside these definitions should be assumed by clients.
+
+---
+
+## Contracts Index
+
+| File | Endpoint | Method |
+|------|----------|--------|
+| `chat_query.json` | `/v1/chat/query` | POST |
+| `barcode_lookup.json` | `/v1/barcode/lookup` | POST |
+| `nutrition_estimate.json` | `/v1/nutrition/estimate` | POST |
+| `recipes_suggest.json` | `/v1/recipes/suggest` | POST |
+| `recipes_discuss.json` | `/v1/recipes/discuss` | POST |
+| `vision_identify.json` | `/v1/vision/identify` | POST |
+| `error_response.json` | shared error schema | — |
+
+---
+
+## Versioning
+
+All public endpoints are versioned via path:
+- `/v1/...` — current stable version
+- `/v2/...` — next version with breaking changes
+
+### Breaking changes (require new version)
+- removing fields
+- adding required fields
+- changing field meaning
+- changing enum semantics
+- changing response structure
+- tightening validation in a way that breaks existing clients
+
+### Non-breaking changes (allowed within version)
+- adding optional fields
+- extending enums (only if clients can safely ignore new values)
+- improving descriptions or documentation
+
+---
+
+## Deprecation Policy
+
+Rules:
+- A new version (`/v2`) must be introduced **before** breaking `/v1`
+- `/v1` and `/v2` must run **in parallel** during migration
+- `/v1` must not be removed without a defined migration window
+
+### Operational guarantees
+- `/v1` remains supported until all known clients migrate
+- Deprecation must be communicated clearly (release notes, API docs, app updates)
+- Breaking existing clients is not allowed
+
+If clients cannot upgrade immediately, **the backend must continue supporting the old version**.
+
+---
+
+## Stability Principle
+
+The backend **owns normalization and abstraction**.
+
+This means:
+- providers may change
+- datasets may change
+- models may change
+
+But:
+- **public contract fields must remain stable**
+- **clients must not depend on backend implementation details**
+
+When a field is exposed publicly, it becomes part of the contract and must be treated as stable.
+
+---
+
+## Profile Resolution Rules
+
+The backend is the **source of truth** for user profile data.
+
+Resolution order:
+1. Stored backend profile (default)
+2. `profile_overrides` in the request (request-scoped only)
+3. System defaults (if no profile exists)
+
+Notes:
+- `profile_overrides` apply only to the current request
+- Overrides are **not persisted**
+- Profile resolution details are internal metadata and are not returned in API responses
+
+---
+
+## Source Metadata Policy
+
+Some endpoints include a `source` object describing where data originated.
+
+Rules:
+- Use **stable identifiers**, not raw file names or vendor strings
+- Represent logical sources, not implementation details
+
+### Important distinction
+
+- `/vision/identify` exposes provider and model identity — vision output is **model-shaped** and results depend on model behavior
+- `/chat/query` hides model identity — output is **fully normalized** and does not require model awareness
+
+This difference is intentional and must remain consistent across versions.
+Clients must not assume all endpoints expose the same level of source detail.
+
+---
+
+## Error Contract
+
+All non-200 responses must follow:
+
+```json
+{
+  "error": {
+    "code": "...",
+    "message": "...",
+    "retryable": true,
+    "request_id": "...",
+    "details": {}
+  }
+}
+```
+
+### HTTP status to error.code
+
+| HTTP Status | error.code           |
+|-------------|----------------------|
+| 400         | BAD_REQUEST          |
+| 401         | UNAUTHORIZED         |
+| 403         | FORBIDDEN            |
+| 404         | NOT_FOUND            |
+| 422         | VALIDATION_ERROR     |
+| 429         | RATE_LIMITED         |
+| 500         | INTERNAL_ERROR       |
+| 503         | UPSTREAM_UNAVAILABLE |
+
+### Expected retryable values
+
+| error.code           | retryable |
+|----------------------|-----------|
+| BAD_REQUEST          | false     |
+| VALIDATION_ERROR     | false     |
+| UNAUTHORIZED         | false     |
+| FORBIDDEN            | false     |
+| NOT_FOUND            | false     |
+| RATE_LIMITED         | true      |
+| UPSTREAM_UNAVAILABLE | true      |
+| INTERNAL_ERROR       | true      |
+
+### Notes
+- `retryable` is advisory backend guidance, not a guarantee
+- `INTERNAL_ERROR` retries must use backoff — do not retry immediately
+- `error.details` structure is non-contractual unless separately documented in a specific endpoint contract
+- `error.message` is human-readable only — clients must not parse or depend on its content
+- Breaking changes to error semantics require a new API version

--- a/contracts/v1/barcode_lookup.json
+++ b/contracts/v1/barcode_lookup.json
@@ -1,0 +1,424 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qima.local/contracts/barcode_lookup.json",
+  "title": "Barcode Lookup API Contract",
+  "description": "Contract-first schema for POST /barcode/lookup request and response.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["endpoint", "method", "request", "responses"],
+  "properties": {
+    "endpoint": {
+      "const": "/barcode/lookup"
+    },
+    "method": {
+      "const": "POST"
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentType", "body"],
+      "properties": {
+        "contentType": {
+          "const": "application/json"
+        },
+        "body": {
+          "$ref": "#/$defs/BarcodeLookupRequest"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["200", "400", "404", "422", "429", "500", "502", "503"],
+      "properties": {
+        "200": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["description", "body"],
+          "properties": {
+            "description": {
+              "const": "Successful barcode lookup"
+            },
+            "body": {
+              "$ref": "#/$defs/BarcodeLookupSuccess"
+            }
+          }
+        },
+        "400": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "404": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "422": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "429": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "500": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "502": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "503": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "BarcodeLookupRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["barcode"],
+      "properties": {
+        "barcode": {
+          "type": "string",
+          "description": "Scanned barcode as digits only.",
+          "pattern": "^[0-9]{8,14}$",
+          "examples": ["5449000000996"]
+        }
+      }
+    },
+    "BarcodeLookupSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_id",
+        "name",
+        "brand",
+        "nutrition",
+        "ingredients",
+        "allergens",
+        "source"
+      ],
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical backend product identifier. For MVP this may be the barcode itself or a normalized source-backed ID.",
+          "examples": ["off:5449000000996"]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["Coca-Cola Original Taste"]
+        },
+        "brand": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["Coca-Cola"]
+        },
+        "nutrition": {
+          "$ref": "#/$defs/Nutrition"
+        },
+        "ingredients": {
+          "type": "array",
+          "description": "Normalized ingredient list in display order.",
+          "items": {
+            "$ref": "#/$defs/Ingredient"
+          }
+        },
+        "allergens": {
+          "type": "array",
+          "description": "Normalized allergen detections derived from source product data.",
+          "items": {
+            "$ref": "#/$defs/Allergen"
+          }
+        },
+        "source": {
+          "$ref": "#/$defs/Source"
+        }
+      }
+    },
+    "Nutrition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["basis", "serving_size", "values"],
+      "properties": {
+        "basis": {
+          "type": "string",
+          "enum": ["per_100g", "per_100ml", "per_serving"]
+        },
+        "serving_size": {
+          "type": ["string", "null"],
+          "examples": ["330 ml", null]
+        },
+        "values": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["energy_kcal", "protein_g", "carbohydrates_g", "fat_g"],
+          "properties": {
+            "energy_kcal": {
+              "type": ["number", "null"]
+            },
+            "protein_g": {
+              "type": ["number", "null"]
+            },
+            "carbohydrates_g": {
+              "type": ["number", "null"]
+            },
+            "fat_g": {
+              "type": ["number", "null"]
+            },
+            "sugars_g": {
+              "type": ["number", "null"]
+            },
+            "fiber_g": {
+              "type": ["number", "null"]
+            },
+            "sodium_mg": {
+              "type": ["number", "null"]
+            },
+            "salt_g": {
+              "type": ["number", "null"]
+            }
+          }
+        }
+      }
+    },
+    "Ingredient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["text", "normalized_text", "is_allergen"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "normalized_text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "is_allergen": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Allergen": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "severity", "source_text"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["milk"]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["contains", "may_contain", "unknown"]
+        },
+        "source_text": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "Source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "provider_product_id", "fetched_at"],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "const": "Open Food Facts API"
+        },
+        "provider_product_id": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["5449000000996"]
+        },
+        "fetched_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ErrorResponseSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "body"],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "#/$defs/ErrorEnvelope"
+        }
+      }
+    },
+    "ErrorEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["error"],
+      "properties": {
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "message"],
+          "properties": {
+            "code": {
+              "type": "string",
+              "enum": [
+                "INVALID_BARCODE",
+                "BAD_REQUEST",
+                "PRODUCT_NOT_FOUND",
+                "VALIDATION_ERROR",
+                "RATE_LIMITED",
+                "UPSTREAM_UNAVAILABLE",
+                "UPSTREAM_ERROR",
+                "INTERNAL_ERROR"
+              ]
+            },
+            "message": {
+              "type": "string",
+              "minLength": 1
+            },
+            "details": {
+              "type": ["object", "array", "string", "null"]
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "endpoint": "/barcode/lookup",
+      "method": "POST",
+      "request": {
+        "contentType": "application/json",
+        "body": {
+          "barcode": "5449000000996"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful barcode lookup",
+          "body": {
+            "product_id": "off:5449000000996",
+            "name": "Coca-Cola Original Taste",
+            "brand": "Coca-Cola",
+            "nutrition": {
+              "basis": "per_100ml",
+              "serving_size": "330 ml",
+              "values": {
+                "energy_kcal": 42,
+                "protein_g": 0,
+                "carbohydrates_g": 10.6,
+                "fat_g": 0,
+                "sugars_g": 10.6,
+                "fiber_g": 0,
+                "sodium_mg": 4,
+                "salt_g": 0.01
+              }
+            },
+            "ingredients": [
+              {
+                "text": "Carbonated water",
+                "normalized_text": "carbonated water",
+                "is_allergen": false
+              },
+              {
+                "text": "Sugar",
+                "normalized_text": "sugar",
+                "is_allergen": false
+              }
+            ],
+            "allergens": [],
+            "source": {
+              "provider": "Open Food Facts API",
+              "provider_product_id": "5449000000996",
+              "fetched_at": "2026-04-19T20:00:00Z"
+            }
+          }
+        },
+        "400": {
+          "description": "Malformed request or invalid barcode format",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "barcode must contain 8 to 14 digits",
+              "retryable": false,
+              "request_id": "req_12345"
+            }
+          }
+        },
+        "404": {
+          "description": "No product found for barcode",
+          "body": {
+            "error": {
+              "code": "PRODUCT_NOT_FOUND",
+              "message": "No product found for the supplied barcode.",
+              "details": {
+                "barcode": "0000000000000"
+              },
+              "retryable": false
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "details": null,
+              "retryable": false
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "details": null,
+              "retryable": true
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "details": null,
+              "retryable": true
+            }
+          }
+        },
+        "502": {
+          "description": "Upstream provider returned an invalid or failed response",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_ERROR",
+              "message": "Upstream provider returned an invalid response.",
+              "details": null,
+              "retryable": true
+            }
+          }
+        },
+        "503": {
+          "description": "Upstream provider unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Barcode provider is currently unavailable.",
+              "details": null,
+              "retryable": true
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/contracts/v1/chat_query.json
+++ b/contracts/v1/chat_query.json
@@ -1,0 +1,208 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "contracts/v1/chat_query.json",
+    "title": "ChatQueryV1",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "endpoint": {
+            "const": "/v1/chat/query"
+        },
+        "method": {
+            "const": "POST"
+        },
+        "request": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "context_id",
+                "question"
+            ],
+            "properties": {
+                "context_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Opaque backend context or session identifier."
+                },
+                "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000,
+                    "description": "User question in natural language."
+                },
+                "conversation_turn_id": {
+                    "type": "string",
+                    "description": "Optional client-generated id for tracing and idempotency."
+                },
+                "locale": {
+                    "type": "string",
+                    "description": "Optional BCP-47 locale such as en or ar-EG."
+                },
+                "profile_overrides": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "Optional temporary overrides for guest mode or explicit per-request override. Stored backend profile remains the default source of truth.",
+                    "properties": {
+                        "dietary_preferences": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "allergens": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "client_timestamp": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "response": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "answer",
+                "source_references",
+                "safety_flags",
+                "latency_ms"
+            ],
+            "properties": {
+                "answer": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Grounded user-facing response."
+                },
+                "source_references": {
+                    "type": "array",
+                    "minItems": 0,
+                    "description": "Structured grounding references used by the backend to support the answer.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "source_id",
+                            "source_type",
+                            "label"
+                        ],
+                        "properties": {
+                            "source_id": {
+                                "type": "string"
+                            },
+                            "source_type": {
+                                "type": "string",
+                                "enum": [
+                                    "open_food_facts",
+                                    "nutrition_dataset",
+                                    "egyptian_food_dataset",
+                                    "fooddata_central",
+                                    "recipe_corpus",
+                                    "comparison_result",
+                                    "session_context",
+                                    "other"
+                                ]
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "excerpt": {
+                                "type": "string"
+                            },
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                            }
+                        }
+                    }
+                },
+                "safety_flags": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "grounded",
+                        "medical_advice_blocked",
+                        "allergen_caution",
+                        "low_confidence"
+                    ],
+                    "properties": {
+                        "grounded": {
+                            "type": "boolean",
+                            "description": "True only when the answer is supported by at least one backend-approved source reference."
+                        },
+                        "medical_advice_blocked": {
+                            "type": "boolean"
+                        },
+                        "allergen_caution": {
+                            "type": "boolean"
+                        },
+                        "low_confidence": {
+                            "type": "boolean"
+                        },
+                        "notes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "latency_ms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Backend end-to-end latency in milliseconds."
+                }
+            }
+        }
+    },
+    "required": [
+        "endpoint",
+        "method",
+        "request",
+        "response"
+    ],
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "response": {
+                        "properties": {
+                            "safety_flags": {
+                                "properties": {
+                                    "grounded": {
+                                        "const": true
+                                    }
+                                },
+                                "required": [
+                                    "grounded"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "safety_flags"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "response": {
+                        "properties": {
+                            "source_references": {
+                                "minItems": 1
+                            }
+                        },
+                        "required": [
+                            "source_references"
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/contracts/v1/error_response.json
+++ b/contracts/v1/error_response.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "contracts/v1/error_response.json",
+  "title": "ErrorResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["error"],
+  "properties": {
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "retryable", "request_id"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "BAD_REQUEST",
+            "UNAUTHORIZED",
+            "FORBIDDEN",
+            "NOT_FOUND",
+            "VALIDATION_ERROR",
+            "RATE_LIMITED",
+            "UPSTREAM_UNAVAILABLE",
+            "INTERNAL_ERROR"
+          ]
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean",
+          "description": "Advisory flag indicating whether retry may succeed later."
+        },
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "details": {
+          "type": "object",
+          "description": "Optional endpoint-specific diagnostic details. Clients must not depend on its structure unless separately documented."
+        }
+      }
+    }
+  }
+}

--- a/contracts/v1/nutrition_estimate.json
+++ b/contracts/v1/nutrition_estimate.json
@@ -1,0 +1,581 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "contracts/v1/nutrition_estimate.json",
+  "title": "Nutrition Estimate API Contract V1",
+  "description": "Contract-first schema for POST /v1/nutrition/estimate request and response.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["endpoint", "method", "request", "responses"],
+  "properties": {
+    "endpoint": {
+      "const": "/v1/nutrition/estimate"
+    },
+    "method": {
+      "const": "POST"
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentType", "body"],
+      "properties": {
+        "contentType": {
+          "const": "application/json"
+        },
+        "body": {
+          "$ref": "#/$defs/NutritionEstimateRequest"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["200", "400", "404", "422", "429", "500", "503"],
+      "properties": {
+        "200": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["description", "body"],
+          "properties": {
+            "description": {
+              "const": "Successful nutrition estimate"
+            },
+            "body": {
+              "$ref": "#/$defs/NutritionEstimateSuccess"
+            }
+          }
+        },
+        "400": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "404": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "422": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "429": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "500": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "503": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "NutritionEstimateRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_type"],
+      "properties": {
+        "input_type": {
+          "type": "string",
+          "enum": ["recognized_dish", "ingredient_set"]
+        },
+        "recognized_dish": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Normalized or candidate dish name when estimating from a recognized meal."
+        },
+        "ingredients": {
+          "type": "array",
+          "description": "Ingredient set used for estimation when no single dish match is available.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "serving_hint": {
+          "type": ["string", "null"],
+          "description": "Optional user or upstream hint about serving size."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "input_type": {
+                "const": "recognized_dish"
+              }
+            },
+            "required": ["input_type"]
+          },
+          "then": {
+            "required": ["recognized_dish"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "input_type": {
+                "const": "ingredient_set"
+              }
+            },
+            "required": ["input_type"]
+          },
+          "then": {
+            "required": ["ingredients"]
+          }
+        }
+      ]
+    },
+    "NutritionEstimateSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "matched_dish",
+        "serving_assumptions",
+        "nutrients",
+        "confidence",
+        "source",
+        "data_quality"
+      ],
+      "properties": {
+        "matched_dish": {
+          "$ref": "#/$defs/MatchedDish"
+        },
+        "serving_assumptions": {
+          "$ref": "#/$defs/ServingAssumptions"
+        },
+        "nutrients": {
+          "$ref": "#/$defs/Nutrients"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Overall backend confidence for the nutrient estimate."
+        },
+        "source": {
+          "$ref": "#/$defs/Source"
+        },
+        "data_quality": {
+          "$ref": "#/$defs/DataQuality"
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Optional backend warnings about sparse data, assumptions, or fallback behavior.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "MatchedDish": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Backend-selected normalized food or dish match used for nutrient estimation."
+        },
+        "match_type": {
+          "type": "string",
+          "enum": ["dish", "ingredient_set", "food_item"],
+          "description": "Backend classification of the selected match."
+        },
+        "match_id": {
+          "type": ["string", "null"],
+          "description": "Optional backend-internal identifier for the matched dish or food."
+        }
+      }
+    },
+    "ServingAssumptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["basis"],
+      "properties": {
+        "basis": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Serving assumption used for nutrient estimation."
+        },
+        "note": {
+          "type": ["string", "null"],
+          "description": "Optional backend note explaining the serving assumption."
+        }
+      }
+    },
+    "Nutrients": {
+      "type": "object",
+      "description": "Normalized nutrient payload owned by the backend. Required keys are always present, but some values may be null when estimation is partial.",
+      "additionalProperties": false,
+      "required": [
+        "calories_kcal",
+        "protein_g",
+        "carbohydrates_g",
+        "fat_g"
+      ],
+      "properties": {
+        "calories_kcal": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "protein_g": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "carbohydrates_g": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "fat_g": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "fiber_g": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "sugar_g": {
+          "type": ["number", "null"],
+          "minimum": 0
+        },
+        "sodium_mg": {
+          "type": ["number", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "Source": {
+      "type": "object",
+      "description": "Normalized source metadata for the nutrition data selected by the backend.",
+      "additionalProperties": false,
+      "required": ["dataset", "source_type"],
+      "properties": {
+        "dataset": {
+          "type": "string",
+          "enum": [
+            "nutrition_xlsx",
+            "egyptian_food_csv",
+            "fdc_foundation",
+            "fdc_sr_legacy"
+          ]
+        },
+        "source_type": {
+          "type": "string",
+          "enum": [
+            "nutrition_dataset",
+            "egyptian_food_dataset",
+            "fooddata_central"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "dataset": {
+                "const": "nutrition_xlsx"
+              }
+            },
+            "required": ["dataset"]
+          },
+          "then": {
+            "properties": {
+              "source_type": {
+                "const": "nutrition_dataset"
+              }
+            },
+            "required": ["source_type"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "dataset": {
+                "const": "egyptian_food_csv"
+              }
+            },
+            "required": ["dataset"]
+          },
+          "then": {
+            "properties": {
+              "source_type": {
+                "const": "egyptian_food_dataset"
+              }
+            },
+            "required": ["source_type"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "dataset": {
+                "enum": ["fdc_foundation", "fdc_sr_legacy"]
+              }
+            },
+            "required": ["dataset"]
+          },
+          "then": {
+            "properties": {
+              "source_type": {
+                "const": "fooddata_central"
+              }
+            },
+            "required": ["source_type"]
+          }
+        }
+      ]
+    },
+    "DataQuality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["completeness"],
+      "properties": {
+        "completeness": {
+          "type": "string",
+          "enum": ["complete", "partial"],
+          "description": "Backend summary of estimate completeness for UI display and warning behavior."
+        }
+      }
+    },
+    "ErrorResponseSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "body"],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "contracts/v1/error_response.json"
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "endpoint": "/v1/nutrition/estimate",
+      "method": "POST",
+      "request": {
+        "contentType": "application/json",
+        "body": {
+          "input_type": "recognized_dish",
+          "recognized_dish": "koshari",
+          "serving_hint": "1 bowl"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful nutrition estimate",
+          "body": {
+            "matched_dish": {
+              "name": "koshari",
+              "match_type": "dish",
+              "match_id": "egy_koshari_001"
+            },
+            "serving_assumptions": {
+              "basis": "1 bowl",
+              "note": "Estimated from normalized dish match and default serving assumption."
+            },
+            "nutrients": {
+              "calories_kcal": 420,
+              "protein_g": 12,
+              "carbohydrates_g": 72,
+              "fat_g": 9,
+              "fiber_g": 8,
+              "sugar_g": 6,
+              "sodium_mg": 540
+            },
+            "confidence": 0.84,
+            "source": {
+              "dataset": "egyptian_food_csv",
+              "source_type": "egyptian_food_dataset"
+            },
+            "data_quality": {
+              "completeness": "complete"
+            },
+            "warnings": []
+          }
+        },
+        "400": {
+          "description": "Malformed request or unsupported estimate input",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request is missing the required estimate input.",
+              "retryable": false,
+              "request_id": "req_20001"
+            }
+          }
+        },
+        "404": {
+          "description": "No matching dish or ingredient data found",
+          "body": {
+            "error": {
+              "code": "NOT_FOUND",
+              "message": "No matching dish or ingredient data found for the supplied estimate input.",
+              "retryable": false,
+              "request_id": "req_20006"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_20002"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_20003"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_20004"
+            }
+          }
+        },
+        "503": {
+          "description": "Nutrition estimation source unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Nutrition estimation source is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_20005"
+            }
+          }
+        }
+      }
+    },
+    {
+      "endpoint": "/v1/nutrition/estimate",
+      "method": "POST",
+      "request": {
+        "contentType": "application/json",
+        "body": {
+          "input_type": "ingredient_set",
+          "ingredients": ["rice", "lentils", "tomato sauce"],
+          "serving_hint": "1 plate"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful nutrition estimate",
+          "body": {
+            "matched_dish": {
+              "name": "koshari",
+              "match_type": "ingredient_set",
+              "match_id": null
+            },
+            "serving_assumptions": {
+              "basis": "1 plate",
+              "note": "Estimated from ingredient-set matching and default serving assumption."
+            },
+            "nutrients": {
+              "calories_kcal": 390,
+              "protein_g": 11,
+              "carbohydrates_g": 68,
+              "fat_g": 7,
+              "fiber_g": 7,
+              "sugar_g": 5,
+              "sodium_mg": null
+            },
+            "confidence": 0.71,
+            "source": {
+              "dataset": "nutrition_xlsx",
+              "source_type": "nutrition_dataset"
+            },
+            "data_quality": {
+              "completeness": "partial"
+            },
+            "warnings": [
+              "Sodium estimate unavailable for one or more matched ingredients."
+            ]
+          }
+        },
+        "400": {
+          "description": "Malformed request or unsupported estimate input",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request is missing the required estimate input.",
+              "retryable": false,
+              "request_id": "req_20011"
+            }
+          }
+        },
+        "404": {
+          "description": "No matching dish or ingredient data found",
+          "body": {
+            "error": {
+              "code": "NOT_FOUND",
+              "message": "No matching dish or ingredient data found for the supplied estimate input.",
+              "retryable": false,
+              "request_id": "req_20012"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_20013"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_20014"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_20015"
+            }
+          }
+        },
+        "503": {
+          "description": "Nutrition estimation source unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Nutrition estimation source is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_20016"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/contracts/v1/recipes_discuss.json
+++ b/contracts/v1/recipes_discuss.json
@@ -1,0 +1,472 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "contracts/v1/recipes_discuss.json",
+  "title": "Recipe Discuss API Contract V1",
+  "description": "Contract-first schema for POST /v1/recipes/discuss request and response. This endpoint does not expose a numeric confidence field; grounding is represented through grounded_references and structured safety output.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["endpoint", "method", "request", "responses"],
+  "properties": {
+    "endpoint": {
+      "const": "/v1/recipes/discuss"
+    },
+    "method": {
+      "const": "POST"
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentType", "body"],
+      "properties": {
+        "contentType": {
+          "const": "application/json"
+        },
+        "body": {
+          "$ref": "#/$defs/RecipeDiscussRequest"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["200", "400", "404", "422", "429", "500", "503"],
+      "properties": {
+        "200": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["description", "body"],
+          "properties": {
+            "description": {
+              "const": "Successful grounded recipe discussion response"
+            },
+            "body": {
+              "$ref": "#/$defs/RecipeDiscussSuccess"
+            }
+          }
+        },
+        "400": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "404": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "422": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "429": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "500": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "503": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "RecipeDiscussRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["question"],
+      "properties": {
+        "recipe_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical recipe identifier when discussing a specific suggested recipe."
+        },
+        "candidate_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Structured recipe candidate context when no single recipe_id is available.",
+          "required": ["title"],
+          "properties": {
+            "title": {
+              "type": "string",
+              "minLength": 1
+            },
+            "matched_ingredients": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "missing_ingredients": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "question": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2000,
+          "description": "User follow-up question about the recipe or candidate context."
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["recipe_id"]
+        },
+        {
+          "required": ["candidate_context"]
+        }
+      ]
+    },
+    "RecipeDiscussSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "answer",
+        "grounded_references",
+        "safety_flags",
+        "latency_ms"
+      ],
+      "properties": {
+        "answer": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Grounded backend answer derived from retrieved recipe references."
+        },
+        "grounded_references": {
+          "type": "array",
+          "description": "Recipe corpus references that support the answer. grounded_references.recipe_id may contain a backend-resolved canonical recipe ID even when the request used candidate_context rather than recipe_id.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/GroundedReference"
+          }
+        },
+        "safety_flags": {
+          "$ref": "#/$defs/SafetyFlags"
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Optional backend warnings about weak grounding, substitutions, or incomplete context.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "latency_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Backend end-to-end latency in milliseconds."
+        }
+      }
+    },
+    "GroundedReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "recipe_id",
+        "title",
+        "reference_type",
+        "reference_text"
+      ],
+      "properties": {
+        "recipe_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reference_type": {
+          "type": "string",
+          "enum": [
+            "ingredient",
+            "instruction",
+            "metadata"
+          ]
+        },
+        "reference_text": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short retrieved recipe snippet used as grounding; not guaranteed to include the full original recipe text."
+        }
+      }
+    },
+    "SafetyFlags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allergen_risk",
+        "undercooked_risk",
+        "cross_contamination_risk",
+        "diet_conflict",
+        "notes"
+      ],
+      "properties": {
+        "allergen_risk": {
+          "type": "boolean"
+        },
+        "undercooked_risk": {
+          "type": "boolean"
+        },
+        "cross_contamination_risk": {
+          "type": "boolean"
+        },
+        "diet_conflict": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": "array",
+          "description": "Human-readable safety notes when one or more risks are present.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "ErrorResponseSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "body"],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "contracts/v1/error_response.json"
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "endpoint": "/v1/recipes/discuss",
+      "method": "POST",
+      "request": {
+        "contentType": "application/json",
+        "body": {
+          "recipe_id": "recipe_001",
+          "question": "Can I replace butter with olive oil in this recipe?"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful grounded recipe discussion response",
+          "body": {
+            "answer": "Yes, olive oil can replace butter in this recipe, but the texture and flavor may change slightly. Use a similar amount and add it during the sauté step rather than as a finishing fat.",
+            "grounded_references": [
+              {
+                "recipe_id": "recipe_001",
+                "title": "Tomato Lentil Skillet",
+                "reference_type": "ingredient",
+                "reference_text": "2 tbsp butter"
+              },
+              {
+                "recipe_id": "recipe_001",
+                "title": "Tomato Lentil Skillet",
+                "reference_type": "instruction",
+                "reference_text": "Melt the butter in a skillet, then sauté the onion and garlic."
+              }
+            ],
+            "safety_flags": {
+              "allergen_risk": false,
+              "undercooked_risk": false,
+              "cross_contamination_risk": false,
+              "diet_conflict": false,
+              "notes": []
+            },
+            "warnings": [],
+            "latency_ms": 734
+          }
+        },
+        "400": {
+          "description": "Malformed request or missing discussion context",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request must include exactly one of recipe_id or candidate_context, plus a question.",
+              "retryable": false,
+              "request_id": "req_30001"
+            }
+          }
+        },
+        "404": {
+          "description": "Recipe or candidate context not found",
+          "body": {
+            "error": {
+              "code": "NOT_FOUND",
+              "message": "No matching recipe context was found for the supplied discussion request.",
+              "retryable": false,
+              "request_id": "req_30002"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_30003"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_30004"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_30005"
+            }
+          }
+        },
+        "503": {
+          "description": "Recipe discussion service unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Recipe discussion service is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_30006"
+            }
+          }
+        }
+      }
+    },
+    {
+      "endpoint": "/v1/recipes/discuss",
+      "method": "POST",
+      "request": {
+        "contentType": "application/json",
+        "body": {
+          "candidate_context": {
+            "title": "Creamy Mushroom Pasta",
+            "matched_ingredients": ["mushrooms", "pasta", "garlic"],
+            "missing_ingredients": ["cream", "parmesan"]
+          },
+          "question": "Is this recipe safe for someone with a dairy allergy?"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful grounded recipe discussion response",
+          "body": {
+            "answer": "Not as written. The recipe context indicates dairy-containing ingredients such as cream and parmesan, so it would conflict with a dairy allergy unless those are replaced with suitable alternatives.",
+            "grounded_references": [
+              {
+                "recipe_id": "recipe_045",
+                "title": "Creamy Mushroom Pasta",
+                "reference_type": "ingredient",
+                "reference_text": "1 cup cream"
+              },
+              {
+                "recipe_id": "recipe_045",
+                "title": "Creamy Mushroom Pasta",
+                "reference_type": "ingredient",
+                "reference_text": "1/2 cup parmesan"
+              },
+              {
+                "recipe_id": "recipe_045",
+                "title": "Creamy Mushroom Pasta",
+                "reference_type": "metadata",
+                "reference_text": "Missing ingredients: cream, parmesan"
+              }
+            ],
+            "safety_flags": {
+              "allergen_risk": true,
+              "undercooked_risk": false,
+              "cross_contamination_risk": false,
+              "diet_conflict": true,
+              "notes": [
+                "Recipe context includes dairy ingredients that may conflict with a dairy allergy."
+              ]
+            },
+            "warnings": [],
+            "latency_ms": 801
+          }
+        },
+        "400": {
+          "description": "Malformed request or missing discussion context",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request must include exactly one of recipe_id or candidate_context, plus a question.",
+              "retryable": false,
+              "request_id": "req_30011"
+            }
+          }
+        },
+        "404": {
+          "description": "Recipe or candidate context not found",
+          "body": {
+            "error": {
+              "code": "NOT_FOUND",
+              "message": "No matching recipe context was found for the supplied discussion request.",
+              "retryable": false,
+              "request_id": "req_30012"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_30013"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_30014"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_30015"
+            }
+          }
+        },
+        "503": {
+          "description": "Recipe discussion service unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Recipe discussion service is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_30016"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/contracts/v1/recipes_suggest.json
+++ b/contracts/v1/recipes_suggest.json
@@ -1,0 +1,513 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "contracts/v1/recipes_suggest.json",
+  "title": "Recipe Suggest API Contract V1",
+  "description": "Contract-first schema for POST /v1/recipes/suggest request and response. This endpoint uses retrieval-first recipe suggestion based on pantry items or recognized ingredients.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["endpoint", "method", "request", "responses"],
+  "properties": {
+    "endpoint": {
+      "const": "/v1/recipes/suggest"
+    },
+    "method": {
+      "const": "POST"
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentType", "body"],
+      "properties": {
+        "contentType": {
+          "const": "application/json"
+        },
+        "body": {
+          "$ref": "#/$defs/RecipeSuggestRequest"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["200", "400", "404", "422", "429", "500", "503"],
+      "properties": {
+        "200": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["description", "body"],
+          "properties": {
+            "description": {
+              "const": "Successful recipe suggestion response"
+            },
+            "body": {
+              "$ref": "#/$defs/RecipeSuggestSuccess"
+            }
+          }
+        },
+        "400": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "404": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "422": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "429": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "500": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "503": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "RecipeSuggestRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pantry_items": {
+          "type": "array",
+          "description": "User pantry items available for recipe suggestion.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "recognized_ingredients": {
+          "type": "array",
+          "description": "Ingredients recognized from prior flows such as vision or manual ingredient extraction.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "dietary_filters": {
+          "type": "array",
+          "description": "Optional dietary filters used to exclude unsuitable recipe candidates.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "excluded_ingredients": {
+          "type": "array",
+          "description": "Ingredients the user does not want included in suggestions.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "max_results": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Maximum number of recipe candidates requested."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["pantry_items"]
+        },
+        {
+          "required": ["recognized_ingredients"]
+        }
+      ]
+    },
+    "RecipeSuggestSuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["recipes", "source", "latency_ms"],
+      "properties": {
+        "recipes": {
+          "type": "array",
+          "description": "Retrieved recipe candidates ranked by backend match logic.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/RecipeCandidate"
+          }
+        },
+        "source": {
+          "$ref": "#/$defs/Source"
+        },
+        "latency_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Backend end-to-end latency in milliseconds."
+        }
+      }
+    },
+    "RecipeCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "recipe_id",
+        "title",
+        "match_score",
+        "matched_ingredients",
+        "missing_ingredients",
+        "exclusions",
+        "warnings",
+        "grounding_metadata"
+      ],
+      "properties": {
+        "recipe_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier from the recipe corpus."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "match_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Backend-computed retrieval score for the recipe candidate."
+        },
+        "matched_ingredients": {
+          "type": "array",
+          "description": "Ingredients from the user context that matched this recipe candidate.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "missing_ingredients": {
+          "type": "array",
+          "description": "Ingredients required by the recipe but not present in the user context.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "exclusions": {
+          "type": "array",
+          "description": "Dietary or ingredient exclusions that were considered while ranking this recipe candidate.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Grounded warnings derived from retrieved recipe content or backend rules.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "grounding_metadata": {
+          "$ref": "#/$defs/GroundingMetadata"
+        }
+      }
+    },
+    "GroundingMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["retrieved_from", "matched_count", "missing_count"],
+      "properties": {
+        "retrieved_from": {
+          "type": "string",
+          "enum": ["recipe_corpus_primary"],
+          "description": "Backend recipe corpus used for retrieval."
+        },
+        "matched_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "missing_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "Source": {
+      "type": "object",
+      "description": "Normalized source metadata for the retrieval corpus used by the backend.",
+      "additionalProperties": false,
+      "required": ["dataset", "retrieval_mode", "source_type"],
+      "properties": {
+        "dataset": {
+          "type": "string",
+          "enum": ["recipe_corpus_primary"],
+          "description": "Stable public identifier for the recipe retrieval corpus."
+        },
+        "retrieval_mode": {
+          "type": "string",
+          "enum": ["retrieval_first"],
+          "description": "Locked retrieval strategy used by the backend."
+        },
+        "source_type": {
+          "type": "string",
+          "enum": ["recipe_corpus"]
+        }
+      }
+    },
+    "ErrorResponseSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "body"],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "contracts/v1/error_response.json"
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "endpoint": "/v1/recipes/suggest",
+      "method": "POST",
+      "request": {
+        "contentType": "application/json",
+        "body": {
+          "pantry_items": ["lentils", "rice", "onion", "tomato sauce"],
+          "dietary_filters": ["vegetarian"],
+          "excluded_ingredients": ["mushrooms"],
+          "max_results": 3
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful recipe suggestion response",
+          "body": {
+            "recipes": [
+              {
+                "recipe_id": "recipe_101",
+                "title": "Simple Koshari Bowl",
+                "match_score": 0.92,
+                "matched_ingredients": ["lentils", "rice", "onion", "tomato sauce"],
+                "missing_ingredients": ["pasta", "chickpeas"],
+                "exclusions": ["vegetarian", "mushrooms"],
+                "warnings": [],
+                "grounding_metadata": {
+                  "retrieved_from": "recipe_corpus_primary",
+                  "matched_count": 4,
+                  "missing_count": 2
+                }
+              },
+              {
+                "recipe_id": "recipe_202",
+                "title": "Lentil Rice Skillet",
+                "match_score": 0.84,
+                "matched_ingredients": ["lentils", "rice", "onion"],
+                "missing_ingredients": ["garlic"],
+                "exclusions": ["vegetarian", "mushrooms"],
+                "warnings": [],
+                "grounding_metadata": {
+                  "retrieved_from": "recipe_corpus_primary",
+                  "matched_count": 3,
+                  "missing_count": 1
+                }
+              }
+            ],
+            "source": {
+              "dataset": "recipe_corpus_primary",
+              "retrieval_mode": "retrieval_first",
+              "source_type": "recipe_corpus"
+            },
+            "latency_ms": 612
+          }
+        },
+        "400": {
+          "description": "Malformed request or missing recipe suggestion input",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request must include pantry_items or recognized_ingredients.",
+              "retryable": false,
+              "request_id": "req_40001"
+            }
+          }
+        },
+        "404": {
+          "description": "No matching recipe suggestions found",
+          "body": {
+            "error": {
+              "code": "NOT_FOUND",
+              "message": "No matching recipe suggestions were found for the supplied input.",
+              "retryable": false,
+              "request_id": "req_40002"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_40003"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_40004"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_40005"
+            }
+          }
+        },
+        "503": {
+          "description": "Recipe suggestion service unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Recipe suggestion service is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_40006"
+            }
+          }
+        }
+      }
+    },
+    {
+      "endpoint": "/v1/recipes/suggest",
+      "method": "POST",
+      "request": {
+        "contentType": "application/json",
+        "body": {
+          "recognized_ingredients": ["chicken", "garlic", "lemon"],
+          "dietary_filters": ["high_protein"],
+          "max_results": 2
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful recipe suggestion response",
+          "body": {
+            "recipes": [
+              {
+                "recipe_id": "recipe_305",
+                "title": "Garlic Lemon Chicken",
+                "match_score": 0.89,
+                "matched_ingredients": ["chicken", "garlic", "lemon"],
+                "missing_ingredients": ["olive oil", "black pepper"],
+                "exclusions": ["high_protein"],
+                "warnings": [],
+                "grounding_metadata": {
+                  "retrieved_from": "recipe_corpus_primary",
+                  "matched_count": 3,
+                  "missing_count": 2
+                }
+              },
+              {
+                "recipe_id": "recipe_411",
+                "title": "Roasted Chicken with Lemon Sauce",
+                "match_score": 0.78,
+                "matched_ingredients": ["chicken", "lemon"],
+                "missing_ingredients": ["butter", "parsley", "garlic"],
+                "exclusions": ["high_protein"],
+                "warnings": [
+                  "One or more core ingredients are missing from the recognized ingredient set."
+                ],
+                "grounding_metadata": {
+                  "retrieved_from": "recipe_corpus_primary",
+                  "matched_count": 2,
+                  "missing_count": 3
+                }
+              }
+            ],
+            "source": {
+              "dataset": "recipe_corpus_primary",
+              "retrieval_mode": "retrieval_first",
+              "source_type": "recipe_corpus"
+            },
+            "latency_ms": 685
+          }
+        },
+        "400": {
+          "description": "Malformed request or missing recipe suggestion input",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request must include pantry_items or recognized_ingredients.",
+              "retryable": false,
+              "request_id": "req_40011"
+            }
+          }
+        },
+        "404": {
+          "description": "No matching recipe suggestions found",
+          "body": {
+            "error": {
+              "code": "NOT_FOUND",
+              "message": "No matching recipe suggestions were found for the supplied input.",
+              "retryable": false,
+              "request_id": "req_40012"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_40013"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_40014"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_40015"
+            }
+          }
+        },
+        "503": {
+          "description": "Recipe suggestion service unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Recipe suggestion service is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_40016"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/contracts/v1/vision_identify.json
+++ b/contracts/v1/vision_identify.json
@@ -1,0 +1,441 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "contracts/v1/vision_identify.json",
+  "title": "Vision Identify API Contract V1",
+  "description": "Contract-first schema for POST /v1/vision/identify request and response. The backend normalizes vision-provider output into a stable mobile-facing contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["endpoint", "method", "request", "responses"],
+  "properties": {
+    "endpoint": {
+      "const": "/v1/vision/identify"
+    },
+    "method": {
+      "const": "POST"
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentType", "body"],
+      "properties": {
+        "contentType": {
+          "const": "multipart/form-data"
+        },
+        "body": {
+          "$ref": "#/$defs/VisionIdentifyRequest"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["200", "400", "422", "429", "500", "503"],
+      "properties": {
+        "200": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["description", "body"],
+          "properties": {
+            "description": {
+              "const": "Successful vision identification response"
+            },
+            "body": {
+              "$ref": "#/$defs/VisionIdentifySuccess"
+            }
+          }
+        },
+        "400": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "422": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "429": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "500": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        },
+        "503": {
+          "$ref": "#/$defs/ErrorResponseSpec"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "VisionIdentifyRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Multipart image file payload supplied by the client."
+        },
+        "locale": {
+          "type": "string",
+          "description": "Optional BCP-47 locale such as en or ar-EG."
+        }
+      }
+    },
+    "VisionIdentifySuccess": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "image_id",
+        "dish_candidates",
+        "ingredients",
+        "confidence",
+        "source",
+        "data_quality"
+      ],
+      "properties": {
+        "image_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Backend-assigned identifier for the uploaded image."
+        },
+        "dish_candidates": {
+          "type": "array",
+          "description": "Ordered candidate dishes recognized from the image.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/DishCandidate"
+          }
+        },
+        "ingredients": {
+          "type": "array",
+          "description": "Structured ingredient candidates extracted from the image. An empty array means no reliable ingredient candidates were returned after backend normalization.",
+          "items": {
+            "$ref": "#/$defs/IngredientCandidate"
+          }
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Overall backend confidence for the identification result."
+        },
+        "source": {
+          "$ref": "#/$defs/Source"
+        },
+        "data_quality": {
+          "$ref": "#/$defs/DataQuality"
+        },
+        "warnings": {
+          "type": "array",
+          "description": "Optional backend warnings about weak identification, sparse ingredient extraction, or fallback behavior.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "latency_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Backend end-to-end latency in milliseconds."
+        }
+      }
+    },
+    "DishCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "confidence"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "IngredientCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "confidence"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "Source": {
+      "type": "object",
+      "description": "Normalized source metadata for the backend vision provider. Public values are stable identifiers rather than raw vendor labels.",
+      "additionalProperties": false,
+      "required": ["provider", "model", "source_type"],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["gemini"],
+          "description": "Current backend vision provider identifier. Additional providers may be introduced in future versions."
+        },
+        "model": {
+          "type": "string",
+          "enum": ["gemini_2_5_flash"],
+          "description": "Current backend vision model identifier. Additional model identifiers may be introduced in future versions."
+        },
+        "source_type": {
+          "type": "string",
+          "enum": ["vision_model"]
+        }
+      }
+    },
+    "DataQuality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["completeness"],
+      "properties": {
+        "completeness": {
+          "type": "string",
+          "enum": ["complete", "partial"],
+          "description": "Backend summary of result completeness for UI display and warning behavior."
+        }
+      }
+    },
+    "ErrorResponseSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "body"],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "contracts/v1/error_response.json"
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "endpoint": "/v1/vision/identify",
+      "method": "POST",
+      "request": {
+        "contentType": "multipart/form-data",
+        "body": {
+          "image": "<binary-image-data>"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful vision identification response",
+          "body": {
+            "image_id": "img_90001",
+            "dish_candidates": [
+              {
+                "name": "koshari",
+                "confidence": 0.88
+              },
+              {
+                "name": "lentil rice bowl",
+                "confidence": 0.61
+              }
+            ],
+            "ingredients": [
+              {
+                "name": "rice",
+                "confidence": 0.92
+              },
+              {
+                "name": "lentils",
+                "confidence": 0.89
+              },
+              {
+                "name": "fried onion",
+                "confidence": 0.73
+              },
+              {
+                "name": "tomato sauce",
+                "confidence": 0.67
+              }
+            ],
+            "confidence": 0.86,
+            "source": {
+              "provider": "gemini",
+              "model": "gemini_2_5_flash",
+              "source_type": "vision_model"
+            },
+            "data_quality": {
+              "completeness": "complete"
+            },
+            "warnings": [],
+            "latency_ms": 942
+          }
+        },
+        "400": {
+          "description": "Malformed request or invalid image input",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request must include a valid image file.",
+              "retryable": false,
+              "request_id": "req_50001"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_50002"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_50003"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_50004"
+            }
+          }
+        },
+        "503": {
+          "description": "Vision identification service unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Vision identification service is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_50005"
+            }
+          }
+        }
+      }
+    },
+    {
+      "endpoint": "/v1/vision/identify",
+      "method": "POST",
+      "request": {
+        "contentType": "multipart/form-data",
+        "body": {
+          "image": "<binary-image-data>",
+          "locale": "en"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful vision identification response",
+          "body": {
+            "image_id": "img_90002",
+            "dish_candidates": [
+              {
+                "name": "grilled chicken plate",
+                "confidence": 0.71
+              },
+              {
+                "name": "roasted chicken meal",
+                "confidence": 0.55
+              }
+            ],
+            "ingredients": [
+              {
+                "name": "chicken",
+                "confidence": 0.94
+              },
+              {
+                "name": "lemon",
+                "confidence": 0.58
+              }
+            ],
+            "confidence": 0.69,
+            "source": {
+              "provider": "gemini",
+              "model": "gemini_2_5_flash",
+              "source_type": "vision_model"
+            },
+            "data_quality": {
+              "completeness": "partial"
+            },
+            "warnings": [
+              "Ingredient extraction may be incomplete due to low visual distinctness."
+            ],
+            "latency_ms": 1018
+          }
+        },
+        "400": {
+          "description": "Malformed request or invalid image input",
+          "body": {
+            "error": {
+              "code": "BAD_REQUEST",
+              "message": "Request must include a valid image file.",
+              "retryable": false,
+              "request_id": "req_50011"
+            }
+          }
+        },
+        "422": {
+          "description": "Request validation failed",
+          "body": {
+            "error": {
+              "code": "VALIDATION_ERROR",
+              "message": "Request body failed schema validation.",
+              "retryable": false,
+              "request_id": "req_50012"
+            }
+          }
+        },
+        "429": {
+          "description": "Rate limit exceeded",
+          "body": {
+            "error": {
+              "code": "RATE_LIMITED",
+              "message": "Too many requests. Try again later.",
+              "retryable": true,
+              "request_id": "req_50013"
+            }
+          }
+        },
+        "500": {
+          "description": "Unexpected internal failure",
+          "body": {
+            "error": {
+              "code": "INTERNAL_ERROR",
+              "message": "Unexpected server error.",
+              "retryable": true,
+              "request_id": "req_50014"
+            }
+          }
+        },
+        "503": {
+          "description": "Vision identification service unavailable",
+          "body": {
+            "error": {
+              "code": "UPSTREAM_UNAVAILABLE",
+              "message": "Vision identification service is currently unavailable.",
+              "retryable": true,
+              "request_id": "req_50015"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
introduce structured JSON schemas under contracts/v1 including chat_query, recipes_suggest, recipes_discuss, vision_identify, nutrition_estimate, barcode_lookup, and error_response along with documentation

ensure strict, backend-owned contract definitions with no free-form fields