### PR TITLE
[mobile] Display vision identification results

### DIFF
--- a/backend/app/api/v1/endpoints/nutrition.py
+++ b/backend/app/api/v1/endpoints/nutrition.py
@@ -1,50 +1,44 @@
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
+from app.api.v1.error_responses import build_error_response
+from app.schemas.v1.error import ErrorCode, ErrorResponse
 from app.schemas.v1.nutrition import (
-    DataQuality,
-    MatchedDish,
-    Nutrients,
     NutritionEstimateRequest,
     NutritionEstimateSuccess,
-    ServingAssumptions,
-    Source,
 )
+from app.services.exceptions import NotFoundError, UpstreamUnavailableError
+from app.services.nutrition_service import estimate_nutrition as estimate_nutrition_with_data
 
 router = APIRouter()
 
 
-@router.post("/estimate", response_model=NutritionEstimateSuccess)
+@router.post(
+    "/estimate",
+    response_model=NutritionEstimateSuccess,
+    responses={
+        404: {"model": ErrorResponse},
+        503: {"model": ErrorResponse},
+    },
+)
 async def estimate_nutrition(
     payload: NutritionEstimateRequest,
-) -> NutritionEstimateSuccess:
-    if payload.recognized_dish:
-        matched_name = payload.recognized_dish
-        match_type = "dish"
-    else:
-        matched_name = ", ".join(payload.ingredients or ["mixed ingredients"])
-        match_type = "ingredient_set"
-
-    return NutritionEstimateSuccess(
-        matched_dish=MatchedDish(
-            name=matched_name,
-            match_type=match_type,
-            match_id="nutrition_stub_001",
-        ),
-        serving_assumptions=ServingAssumptions(
-            basis=payload.serving_hint or "one typical serving",
-            note="Mock serving assumption for API integration testing.",
-        ),
-        nutrients=Nutrients(
-            calories_kcal=520,
-            protein_g=24,
-            carbohydrates_g=68,
-            fat_g=16,
-            fiber_g=9,
-            sugar_g=6,
-            sodium_mg=430,
-        ),
-        confidence=0.7,
-        source=Source(dataset="egyptian_food_csv", source_type="egyptian_food_dataset"),
-        data_quality=DataQuality(completeness="partial"),
-        warnings=["Mock response. Nutrition values are estimates."],
-    )
+) -> NutritionEstimateSuccess | JSONResponse:
+    try:
+        return estimate_nutrition_with_data(payload)
+    except NotFoundError:
+        return build_error_response(
+            status_code=404,
+            code=ErrorCode.NOT_FOUND,
+            message="No matching dish or ingredient data found for the supplied estimate input.",
+            retryable=False,
+            details={},
+        )
+    except UpstreamUnavailableError:
+        return build_error_response(
+            status_code=503,
+            code=ErrorCode.UPSTREAM_UNAVAILABLE,
+            message="Nutrition estimation source is currently unavailable.",
+            retryable=True,
+            details={},
+        )

--- a/backend/app/services/nutrition_service.py
+++ b/backend/app/services/nutrition_service.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from app.schemas.v1.nutrition import (
+    DataCompleteness,
+    DataQuality,
+    MatchType,
+    MatchedDish,
+    Nutrients,
+    NutritionDataset,
+    NutritionEstimateInputType,
+    NutritionEstimateRequest,
+    NutritionEstimateSuccess,
+    NutritionSourceType,
+    ServingAssumptions,
+    Source,
+)
+from app.services.exceptions import NotFoundError, UpstreamUnavailableError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_DATA_DIR = REPO_ROOT / "data" / "Food"
+
+NUTRITION_XLSX = "nutrition.xlsx"
+EGYPTIAN_FOOD_CSV = "Egyptian Food.csv"
+FDC_FOUNDATION_JSON = "FoodData_Central_foundation_food_json_2025-12-18.json"
+FDC_SR_LEGACY_JSON = "FoodData_Central_sr_legacy_food_json_2018-04.json"
+CSV_ENCODINGS = ("utf-8-sig", "cp1252", "latin1")
+
+CORE_NUTRIENTS = ("calories_kcal", "protein_g", "carbohydrates_g", "fat_g")
+FDC_NUTRIENT_MAP = {
+    1008: "calories_kcal",
+    1003: "protein_g",
+    1005: "carbohydrates_g",
+    1004: "fat_g",
+    1079: "fiber_g",
+    2000: "sugar_g",
+    1093: "sodium_mg",
+}
+FDC_NUTRIENT_NAME_MAP = {
+    "energy": "calories_kcal",
+    "protein": "protein_g",
+    "carbohydrate, by difference": "carbohydrates_g",
+    "total lipid (fat)": "fat_g",
+    "fiber, total dietary": "fiber_g",
+    "total sugars": "sugar_g",
+    "sugars, total": "sugar_g",
+    "sugars, total including nlea": "sugar_g",
+    "sodium, na": "sodium_mg",
+}
+
+
+@dataclass(frozen=True)
+class NutritionValues:
+    calories_kcal: float | None
+    protein_g: float | None
+    carbohydrates_g: float | None
+    fat_g: float | None
+    fiber_g: float | None = None
+    sugar_g: float | None = None
+    sodium_mg: float | None = None
+
+    def as_schema(self) -> Nutrients:
+        return Nutrients(
+            calories_kcal=self.calories_kcal,
+            protein_g=self.protein_g,
+            carbohydrates_g=self.carbohydrates_g,
+            fat_g=self.fat_g,
+            fiber_g=self.fiber_g,
+            sugar_g=self.sugar_g,
+            sodium_mg=self.sodium_mg,
+        )
+
+    def has_core_nutrients(self) -> bool:
+        return all(getattr(self, key) is not None for key in CORE_NUTRIENTS)
+
+
+@dataclass(frozen=True)
+class NutritionRecord:
+    name: str
+    normalized_name: str
+    normalized_primary_name: str
+    normalized_aliases: set[str]
+    tokens: set[str]
+    serving_size: str | None
+    nutrients: NutritionValues
+    dataset: NutritionDataset
+    source_type: NutritionSourceType
+    match_id: str
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    record: NutritionRecord
+    confidence: float
+    match_kind: str
+
+
+class NutritionService:
+    def __init__(self, *, data_dir: Path | None = None) -> None:
+        self._data_dir = data_dir or DEFAULT_DATA_DIR
+        self._records_by_dataset: dict[NutritionDataset, list[NutritionRecord]] | None = None
+
+    def estimate(self, payload: NutritionEstimateRequest) -> NutritionEstimateSuccess:
+        if payload.input_type == NutritionEstimateInputType.RECOGNIZED_DISH:
+            return self._estimate_recognized_dish(payload)
+        return self._estimate_ingredient_set(
+            ingredients=payload.ingredients or [],
+            serving_hint=payload.serving_hint,
+            fallback_warning=None,
+        )
+
+    def _estimate_recognized_dish(
+        self, payload: NutritionEstimateRequest
+    ) -> NutritionEstimateSuccess:
+        dish_name = payload.recognized_dish or ""
+        match = self._find_best_match(dish_name)
+        if match is not None:
+            warnings = _match_warnings(dish_name, match)
+            return _single_match_response(
+                match=match,
+                query=dish_name,
+                match_type=MatchType.DISH,
+                serving_hint=payload.serving_hint,
+                warnings=warnings,
+            )
+
+        if payload.ingredients:
+            return self._estimate_ingredient_set(
+                ingredients=payload.ingredients,
+                serving_hint=payload.serving_hint,
+                fallback_warning=(
+                    f"No direct nutrition match found for '{dish_name}'. "
+                    "Estimated from recognized ingredients instead."
+                ),
+            )
+
+        raise NotFoundError("No matching dish or ingredient data found.")
+
+    def _estimate_ingredient_set(
+        self,
+        *,
+        ingredients: list[str],
+        serving_hint: str | None,
+        fallback_warning: str | None,
+    ) -> NutritionEstimateSuccess:
+        matched: list[tuple[str, MatchResult]] = []
+        missing: list[str] = []
+        warnings: list[str] = []
+        if fallback_warning:
+            warnings.append(fallback_warning)
+
+        for ingredient in _distinct_text(ingredients):
+            match = self._find_best_match(ingredient)
+            if match is None:
+                missing.append(ingredient)
+                continue
+            matched.append((ingredient, match))
+            warnings.extend(_match_warnings(ingredient, match))
+
+        if not matched:
+            raise NotFoundError("No matching dish or ingredient data found.")
+
+        nutrients = _average_nutrients([match.record.nutrients for _, match in matched])
+        completeness = (
+            DataCompleteness.COMPLETE
+            if not missing and nutrients.has_core_nutrients()
+            else DataCompleteness.PARTIAL
+        )
+        if missing:
+            warnings.append(
+                "No nutrition match found for: " + ", ".join(missing) + "."
+            )
+        if not nutrients.has_core_nutrients():
+            warnings.append("One or more core nutrient values are unavailable.")
+
+        source = _source_for_matches([match for _, match in matched], warnings)
+        confidence = _ingredient_set_confidence(
+            matched_count=len(matched),
+            requested_count=len(_distinct_text(ingredients)),
+            matches=[match for _, match in matched],
+        )
+        matched_names = [match.record.name for _, match in matched]
+
+        return NutritionEstimateSuccess(
+            matched_dish=MatchedDish(
+                name=", ".join(matched_names),
+                match_type=MatchType.INGREDIENT_SET,
+                match_id=None,
+            ),
+            serving_assumptions=ServingAssumptions(
+                basis=serving_hint or "100 g composite serving",
+                note="Estimated as an equal-weight composite of matched ingredients.",
+            ),
+            nutrients=nutrients.as_schema(),
+            confidence=confidence,
+            source=source,
+            data_quality=DataQuality(completeness=completeness),
+            warnings=_unique_warnings(warnings),
+        )
+
+    def _find_best_match(self, query: str) -> MatchResult | None:
+        query_normalized = _normalize_name(query)
+        query_tokens = _tokens(query_normalized)
+        if not query_normalized or not query_tokens:
+            return None
+
+        for dataset in (
+            NutritionDataset.NUTRITION_XLSX,
+            NutritionDataset.EGYPTIAN_FOOD_CSV,
+            NutritionDataset.FDC_FOUNDATION,
+            NutritionDataset.FDC_SR_LEGACY,
+        ):
+            best: MatchResult | None = None
+            for record in self._records_by_dataset_loaded().get(dataset, []):
+                candidate = _score_match(
+                    query_normalized=query_normalized,
+                    query_tokens=query_tokens,
+                    record=record,
+                )
+                if candidate is None:
+                    continue
+                if best is None or candidate.confidence > best.confidence:
+                    best = candidate
+            if best is not None:
+                return best
+
+        return None
+
+    def _records_by_dataset_loaded(self) -> dict[NutritionDataset, list[NutritionRecord]]:
+        if self._records_by_dataset is not None:
+            return self._records_by_dataset
+
+        try:
+            records_by_dataset = {
+                NutritionDataset.NUTRITION_XLSX: self._load_nutrition_xlsx(),
+                NutritionDataset.EGYPTIAN_FOOD_CSV: self._load_egyptian_food_csv(),
+                NutritionDataset.FDC_FOUNDATION: self._load_fdc_json(
+                    filename=FDC_FOUNDATION_JSON,
+                    root_key="FoundationFoods",
+                    dataset=NutritionDataset.FDC_FOUNDATION,
+                ),
+                NutritionDataset.FDC_SR_LEGACY: self._load_fdc_json(
+                    filename=FDC_SR_LEGACY_JSON,
+                    root_key="SRLegacyFoods",
+                    dataset=NutritionDataset.FDC_SR_LEGACY,
+                ),
+            }
+        except UpstreamUnavailableError:
+            raise
+        except Exception as exc:
+            raise UpstreamUnavailableError(
+                "Nutrition data sources are currently unavailable."
+            ) from exc
+
+        if not records_by_dataset[NutritionDataset.NUTRITION_XLSX]:
+            raise UpstreamUnavailableError("nutrition.xlsx contains no usable foods.")
+
+        self._records_by_dataset = records_by_dataset
+        return records_by_dataset
+
+    def _load_nutrition_xlsx(self) -> list[NutritionRecord]:
+        path = self._data_dir / NUTRITION_XLSX
+        if not path.exists():
+            raise UpstreamUnavailableError("nutrition.xlsx is not available.")
+
+        try:
+            frame = pd.read_excel(path)
+        except Exception as exc:
+            raise UpstreamUnavailableError("nutrition.xlsx could not be read.") from exc
+
+        records: list[NutritionRecord] = []
+        for index, row in frame.iterrows():
+            name = _text(row.get("name"))
+            if not name:
+                continue
+            records.append(
+                _record(
+                    name=name,
+                    serving_size=_text(row.get("serving_size")) or None,
+                    nutrients=NutritionValues(
+                        calories_kcal=_number(row.get("calories")),
+                        protein_g=_number(row.get("protein")),
+                        carbohydrates_g=_number(row.get("carbohydrate")),
+                        fat_g=_number(row.get("fat")),
+                        fiber_g=_number(row.get("fiber")),
+                        sugar_g=_number(row.get("sugars")),
+                        sodium_mg=_number(row.get("sodium")),
+                    ),
+                    dataset=NutritionDataset.NUTRITION_XLSX,
+                    source_type=NutritionSourceType.NUTRITION_DATASET,
+                    match_id=f"nutrition_xlsx:{index}",
+                )
+            )
+        return records
+
+    def _load_egyptian_food_csv(self) -> list[NutritionRecord]:
+        path = self._data_dir / EGYPTIAN_FOOD_CSV
+        if not path.exists():
+            return []
+
+        try:
+            frame = _read_csv_with_encoding_fallback(path)
+        except Exception as exc:
+            raise UpstreamUnavailableError("Egyptian Food.csv could not be read.") from exc
+        frame = frame.drop(
+            columns=[
+                column
+                for column in frame.columns
+                if str(column).strip().lower().startswith("unnamed:")
+            ],
+            errors="ignore",
+        )
+
+        records: list[NutritionRecord] = []
+        for index, row in frame.iterrows():
+            name = _first_text(row, ["FOOD", "name", "dish", "food", "food_name"])
+            if not name:
+                continue
+            records.append(
+                _record(
+                    name=name,
+                    serving_size="100 g",
+                    nutrients=NutritionValues(
+                        calories_kcal=_first_number(
+                            row, ["ENERGY (Kcal)", "calories_kcal", "calories", "energy_kcal"]
+                        ),
+                        protein_g=_first_number(row, ["PROTEIN (g)", "protein_g", "protein"]),
+                        carbohydrates_g=_first_number(
+                            row,
+                            [
+                                "CARBOHYDRATE  (g)",
+                                "CARBOHYDRATE (g)",
+                                "carbohydrates_g",
+                                "carbohydrate",
+                                "carbs_g",
+                                "carbs",
+                            ],
+                        ),
+                        fat_g=_first_number(row, ["FAT (g)", "fat_g", "fat", "total_fat"]),
+                        fiber_g=_first_number(row, ["FIBER (g)", "fiber_g", "fiber"]),
+                        sugar_g=_first_number(row, ["sugar_g", "sugars_g", "sugars"]),
+                        sodium_mg=_first_number(row, ["SODIUM (mg)", "sodium_mg", "sodium"]),
+                    ),
+                    dataset=NutritionDataset.EGYPTIAN_FOOD_CSV,
+                    source_type=NutritionSourceType.EGYPTIAN_FOOD_DATASET,
+                    match_id=f"egyptian_food_csv:{index}",
+                )
+            )
+        return records
+
+    def _load_fdc_json(
+        self,
+        *,
+        filename: str,
+        root_key: str,
+        dataset: NutritionDataset,
+    ) -> list[NutritionRecord]:
+        path = self._data_dir / filename
+        if not path.exists():
+            return []
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise UpstreamUnavailableError(f"{filename} could not be read.") from exc
+
+        foods = payload.get(root_key)
+        if not isinstance(foods, list):
+            return []
+
+        records: list[NutritionRecord] = []
+        for food in foods:
+            if not isinstance(food, dict):
+                continue
+            name = _text(food.get("description"))
+            if not name:
+                continue
+            nutrients = _fdc_nutrients(food.get("foodNutrients"))
+            records.append(
+                _record(
+                    name=name,
+                    serving_size="100 g",
+                    nutrients=nutrients,
+                    dataset=dataset,
+                    source_type=NutritionSourceType.FOODDATA_CENTRAL,
+                    match_id=f"fdc:{food.get('fdcId') or food.get('ndbNumber') or len(records)}",
+                )
+            )
+        return records
+
+
+def _single_match_response(
+    *,
+    match: MatchResult,
+    query: str,
+    match_type: MatchType,
+    serving_hint: str | None,
+    warnings: list[str],
+) -> NutritionEstimateSuccess:
+    nutrients = match.record.nutrients
+    completeness = (
+        DataCompleteness.COMPLETE
+        if nutrients.has_core_nutrients()
+        else DataCompleteness.PARTIAL
+    )
+    if not nutrients.has_core_nutrients():
+        warnings.append("One or more core nutrient values are unavailable.")
+
+    return NutritionEstimateSuccess(
+        matched_dish=MatchedDish(
+            name=match.record.name,
+            match_type=match_type,
+            match_id=match.record.match_id,
+        ),
+        serving_assumptions=ServingAssumptions(
+            basis=serving_hint or match.record.serving_size or "100 g",
+            note=(
+                f"Matched '{query}' to nutrition source row '{match.record.name}'. "
+                "Values are estimated from the matched data source."
+            ),
+        ),
+        nutrients=nutrients.as_schema(),
+        confidence=match.confidence,
+        source=Source(
+            dataset=match.record.dataset,
+            source_type=match.record.source_type,
+        ),
+        data_quality=DataQuality(completeness=completeness),
+        warnings=_unique_warnings(warnings),
+    )
+
+
+def _record(
+    *,
+    name: str,
+    serving_size: str | None,
+    nutrients: NutritionValues,
+    dataset: NutritionDataset,
+    source_type: NutritionSourceType,
+    match_id: str,
+) -> NutritionRecord:
+    normalized = _normalize_name(name)
+    normalized_primary = _normalize_name(_primary_name(name))
+    normalized_aliases = {
+        normalized_alias
+        for alias in _parenthetical_aliases(name)
+        if (normalized_alias := _normalize_name(alias))
+    }
+    return NutritionRecord(
+        name=name,
+        normalized_name=normalized,
+        normalized_primary_name=normalized_primary,
+        normalized_aliases=normalized_aliases,
+        tokens=_tokens(normalized),
+        serving_size=serving_size,
+        nutrients=nutrients,
+        dataset=dataset,
+        source_type=source_type,
+        match_id=match_id,
+    )
+
+
+def _score_match(
+    *,
+    query_normalized: str,
+    query_tokens: set[str],
+    record: NutritionRecord,
+) -> MatchResult | None:
+    if query_normalized == record.normalized_name:
+        return MatchResult(record=record, confidence=0.95, match_kind="exact")
+
+    if query_normalized == record.normalized_primary_name:
+        return MatchResult(record=record, confidence=0.86, match_kind="fuzzy")
+
+    if query_normalized in record.normalized_aliases:
+        return MatchResult(record=record, confidence=0.84, match_kind="fuzzy")
+
+    if len(query_tokens) == 1:
+        return None
+
+    if query_tokens.issubset(record.tokens):
+        return MatchResult(record=record, confidence=0.78, match_kind="fuzzy")
+
+    overlap = len(query_tokens & record.tokens) / max(len(query_tokens), 1)
+    if overlap >= 0.75:
+        return MatchResult(record=record, confidence=0.68, match_kind="fuzzy")
+
+    return None
+
+
+def _match_warnings(query: str, match: MatchResult) -> list[str]:
+    if match.match_kind == "exact":
+        return []
+    return [f"Matched '{query}' to '{match.record.name}' using fuzzy matching."]
+
+
+def _average_nutrients(values: list[NutritionValues]) -> NutritionValues:
+    def average(key: str) -> float | None:
+        present = [getattr(item, key) for item in values if getattr(item, key) is not None]
+        if not present:
+            return None
+        return round(sum(present) / len(present), 3)
+
+    return NutritionValues(
+        calories_kcal=average("calories_kcal"),
+        protein_g=average("protein_g"),
+        carbohydrates_g=average("carbohydrates_g"),
+        fat_g=average("fat_g"),
+        fiber_g=average("fiber_g"),
+        sugar_g=average("sugar_g"),
+        sodium_mg=average("sodium_mg"),
+    )
+
+
+def _source_for_matches(matches: list[MatchResult], warnings: list[str]) -> Source:
+    priority = {
+        NutritionDataset.NUTRITION_XLSX: 0,
+        NutritionDataset.EGYPTIAN_FOOD_CSV: 1,
+        NutritionDataset.FDC_FOUNDATION: 2,
+        NutritionDataset.FDC_SR_LEGACY: 3,
+    }
+    datasets = {match.record.dataset for match in matches}
+    selected = min(datasets, key=lambda dataset: priority[dataset])
+    selected_source_type = {
+        NutritionDataset.NUTRITION_XLSX: NutritionSourceType.NUTRITION_DATASET,
+        NutritionDataset.EGYPTIAN_FOOD_CSV: NutritionSourceType.EGYPTIAN_FOOD_DATASET,
+        NutritionDataset.FDC_FOUNDATION: NutritionSourceType.FOODDATA_CENTRAL,
+        NutritionDataset.FDC_SR_LEGACY: NutritionSourceType.FOODDATA_CENTRAL,
+    }[selected]
+    if len(datasets) > 1:
+        warnings.append("Multiple nutrition data sources were used for this estimate.")
+    return Source(dataset=selected, source_type=selected_source_type)
+
+
+def _ingredient_set_confidence(
+    *,
+    matched_count: int,
+    requested_count: int,
+    matches: list[MatchResult],
+) -> float:
+    if requested_count <= 0 or not matches:
+        return 0.0
+    coverage = matched_count / requested_count
+    average_match = sum(match.confidence for match in matches) / len(matches)
+    return round(max(0.0, min(0.9, coverage * average_match)), 3)
+
+
+def _fdc_nutrients(raw_nutrients: Any) -> NutritionValues:
+    values: dict[str, float] = {}
+    if isinstance(raw_nutrients, list):
+        for item in raw_nutrients:
+            if not isinstance(item, dict):
+                continue
+            nutrient = item.get("nutrient")
+            if not isinstance(nutrient, dict):
+                continue
+            key = FDC_NUTRIENT_MAP.get(nutrient.get("id"))
+            if key is None:
+                nutrient_name = _normalize_nutrient_name(nutrient.get("name"))
+                key = FDC_NUTRIENT_NAME_MAP.get(nutrient_name)
+            if key is None:
+                continue
+            if key == "calories_kcal" and _text(nutrient.get("unitName")).lower() != "kcal":
+                continue
+            amount = _number(item.get("amount"))
+            if amount is not None:
+                values[key] = amount
+
+    return NutritionValues(
+        calories_kcal=values.get("calories_kcal"),
+        protein_g=values.get("protein_g"),
+        carbohydrates_g=values.get("carbohydrates_g"),
+        fat_g=values.get("fat_g"),
+        fiber_g=values.get("fiber_g"),
+        sugar_g=values.get("sugar_g"),
+        sodium_mg=values.get("sodium_mg"),
+    )
+
+
+def _first_text(row: Any, keys: list[str]) -> str:
+    for key in keys:
+        value = _text(row.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _first_number(row: Any, keys: list[str]) -> float | None:
+    for key in keys:
+        value = _number(row.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _read_csv_with_encoding_fallback(path: Path) -> pd.DataFrame:
+    last_error: Exception | None = None
+    for encoding in CSV_ENCODINGS:
+        try:
+            return pd.read_csv(path, encoding=encoding)
+        except UnicodeDecodeError as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    return pd.read_csv(path)
+
+
+def _number(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except TypeError:
+        pass
+    if isinstance(value, (int, float)):
+        return float(value)
+    cleaned = str(value).replace(",", "").strip()
+    if not cleaned:
+        return None
+    match = re.search(r"[-+]?\d*\.?\d+", cleaned)
+    if match is None:
+        return None
+    return float(match.group(0))
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except TypeError:
+        pass
+    return str(value).strip()
+
+
+def _normalize_name(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", " ", value.lower())
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def _primary_name(value: str) -> str:
+    without_parentheticals = re.sub(r"\([^)]*\)", " ", value)
+    return re.split(r"[,;/]", without_parentheticals, maxsplit=1)[0].strip()
+
+
+def _parenthetical_aliases(value: str) -> list[str]:
+    return re.findall(r"\(([^)]*)\)", value)
+
+
+def _normalize_nutrient_name(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def _tokens(normalized: str) -> set[str]:
+    tokens: set[str] = set()
+    for token in normalized.split():
+        if not token:
+            continue
+        tokens.add(token)
+        if len(token) > 3 and token.endswith("s"):
+            tokens.add(token[:-1])
+    return tokens
+
+
+def _distinct_text(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    distinct: list[str] = []
+    for value in values:
+        cleaned = _text(value)
+        key = _normalize_name(cleaned)
+        if not cleaned or not key or key in seen:
+            continue
+        seen.add(key)
+        distinct.append(cleaned)
+    return distinct
+
+
+def _unique_warnings(warnings: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for warning in warnings:
+        cleaned = warning.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        unique.append(cleaned)
+    return unique
+
+
+nutrition_service = NutritionService()
+
+
+def estimate_nutrition(payload: NutritionEstimateRequest) -> NutritionEstimateSuccess:
+    return nutrition_service.estimate(payload)

--- a/backend/app/services/vision_service.py
+++ b/backend/app/services/vision_service.py
@@ -293,7 +293,16 @@ def _build_prompt(locale: str | None) -> str:
         "candidates with confidence scores from 0 to 1. Include at least one dish "
         "candidate; if no food is visible, use the name 'unknown food item' with low "
         "confidence and add a warning. Do not estimate nutrients, prices, medical "
-        "advice, or recipe instructions."
+        "advice, or recipe instructions. Prioritize Egyptian dishes and foods "
+        "commonly available in Egypt when the image evidence supports them. When "
+        "a food could be either an Egyptian/local Egyptian dish or a similar "
+        "international dish, rank the Egyptian/common-in-Egypt name first; for "
+        "example, prefer 'macaroni bechamel' over 'pastitsio' when both fit the "
+        "image. Use the simplest accurate food name when the image evidence is "
+        "simple. Do not add preparation, coating, seasoning, or flavor adjectives "
+        "unless they are clearly visible; for example, use 'walnuts' instead of "
+        "'glazed walnuts' and 'cashews' instead of 'seasoned cashews' when those "
+        "extra details are not visually supported."
     )
     if locale:
         prompt += f" User locale: {locale}."

--- a/backend/app/tests/test_nutrition_service.py
+++ b/backend/app/tests/test_nutrition_service.py
@@ -1,0 +1,393 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.schemas.v1.nutrition import NutritionEstimateRequest
+from app.services.exceptions import NotFoundError, UpstreamUnavailableError
+from app.services.nutrition_service import (
+    FDC_FOUNDATION_JSON,
+    NutritionService,
+)
+
+
+def _write_nutrition_xlsx(path: Path, rows: list[dict]) -> None:
+    pd.DataFrame(rows).to_excel(path, index=False)
+
+
+def _write_egyptian_food_csv(path: Path, rows: list[dict]) -> None:
+    columns = [
+        "FOOD",
+        "REFUSE (%)",
+        "WATER (g)",
+        "ENERGY (Kcal)",
+        "PROTEIN (g)",
+        "FAT (g)",
+        "ASH (g)",
+        "FIBER (g)",
+        "CARBOHYDRATE  (g)",
+        "SODIUM (mg)",
+        "POTASSIUM (mg)",
+        "CALCIUM (mg)",
+        "PHOSPHORUS (mg)",
+        "MAGNESIUM (mg)",
+        "IRON (mg)",
+        "ZINC (mg)",
+        "COPPER (mg)",
+        "VITAMIN A (ugre)",
+        "VITAMIN C (mg)",
+        "THIAMIN (mg)",
+        "REBOFLAVIN (mg)",
+        "Unnamed: 21",
+    ]
+    frame = pd.DataFrame(rows, columns=columns)
+    path.write_bytes(frame.to_csv(index=False).encode("cp1252"))
+
+
+def _base_row(name: str, **overrides: object) -> dict:
+    row = {
+        "name": name,
+        "serving_size": "100 g",
+        "calories": 100,
+        "protein": "2 g",
+        "carbohydrate": "20 g",
+        "fat": "1 g",
+        "fiber": "1 g",
+        "sugars": "0.5 g",
+        "sodium": "5 mg",
+    }
+    row.update(overrides)
+    return row
+
+
+def _egyptian_row(food: str, **overrides: object) -> dict:
+    row = {
+        "FOOD": food,
+        "REFUSE (%)": 0,
+        "WATER (g)": 50,
+        "ENERGY (Kcal)": 100,
+        "PROTEIN (g)": 5,
+        "FAT (g)": 2,
+        "ASH (g)": 1,
+        "FIBER (g)": 1,
+        "CARBOHYDRATE  (g)": 20,
+        "SODIUM (mg)": 10,
+        "POTASSIUM (mg)": 20,
+        "CALCIUM (mg)": 30,
+        "PHOSPHORUS (mg)": 40,
+        "MAGNESIUM (mg)": 50,
+        "IRON (mg)": 1,
+        "ZINC (mg)": 1,
+        "COPPER (mg)": 0.1,
+        "VITAMIN A (ugre)": "T",
+        "VITAMIN C (mg)": 0,
+        "THIAMIN (mg)": 0.1,
+        "REBOFLAVIN (mg)": 0.1,
+        "Unnamed: 21": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_estimate_exact_xlsx_food_match(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(
+        tmp_path / "nutrition.xlsx",
+        [_base_row("Cornstarch", calories=381, protein="0.26 g", carbohydrate="91.27 g")],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="recognized_dish",
+            recognized_dish="Cornstarch",
+        )
+    )
+
+    assert result.matched_dish.name == "Cornstarch"
+    assert result.matched_dish.match_type == "dish"
+    assert result.nutrients.calories_kcal == 381
+    assert result.nutrients.protein_g == 0.26
+    assert result.nutrients.carbohydrates_g == 91.27
+    assert result.source.dataset == "nutrition_xlsx"
+    assert result.data_quality.completeness == "complete"
+    assert result.warnings == []
+
+
+def test_short_query_matches_base_food_not_qualifier(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(
+        tmp_path / "nutrition.xlsx",
+        [
+            _base_row("Butter, without salt", calories=717, sodium="11 mg"),
+            _base_row(
+                "Salt, table",
+                calories=0,
+                protein="0 g",
+                carbohydrate="0 g",
+                fat="0 g",
+                sodium="38758 mg",
+            ),
+        ],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="recognized_dish",
+            recognized_dish="salt",
+        )
+    )
+
+    assert result.matched_dish.name == "Salt, table"
+    assert result.nutrients.calories_kcal == 0
+    assert result.nutrients.sodium_mg == 38758
+    assert result.source.dataset == "nutrition_xlsx"
+
+
+def test_short_ingredient_query_ignores_qualifier_only_matches(
+    tmp_path: Path,
+) -> None:
+    _write_nutrition_xlsx(
+        tmp_path / "nutrition.xlsx",
+        [_base_row("Butter, without salt", calories=717, sodium="11 mg")],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    with pytest.raises(NotFoundError):
+        service.estimate(
+            NutritionEstimateRequest(
+                input_type="ingredient_set",
+                ingredients=["salt"],
+            )
+        )
+
+
+def test_estimate_uses_cp1252_egyptian_csv_after_xlsx_miss(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(tmp_path / "nutrition.xlsx", [_base_row("Cornstarch")])
+    _write_egyptian_food_csv(
+        tmp_path / "Egyptian Food.csv",
+        [
+            _egyptian_row(
+                "rice\xa0(koshari)",
+                **{
+                    "ENERGY (Kcal)": 172,
+                    "PROTEIN (g)": 6.5,
+                    "FAT (g)": 5.2,
+                    "CARBOHYDRATE  (g)": 24.7,
+                    "FIBER (g)": 1.1,
+                    "SODIUM (mg)": 324,
+                },
+            )
+        ],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="recognized_dish",
+            recognized_dish="koshari",
+        )
+    )
+
+    assert result.matched_dish.name == "rice\xa0(koshari)"
+    assert result.nutrients.calories_kcal == 172
+    assert result.nutrients.protein_g == 6.5
+    assert result.nutrients.fat_g == 5.2
+    assert result.nutrients.carbohydrates_g == 24.7
+    assert result.nutrients.fiber_g == 1.1
+    assert result.nutrients.sodium_mg == 324
+    assert result.serving_assumptions.basis == "100 g"
+    assert result.source.dataset == "egyptian_food_csv"
+    assert result.source.source_type == "egyptian_food_dataset"
+    assert result.data_quality.completeness == "complete"
+
+
+def test_estimate_uses_egyptian_csv_for_local_food_alias(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(tmp_path / "nutrition.xlsx", [_base_row("Cornstarch")])
+    _write_egyptian_food_csv(
+        tmp_path / "Egyptian Food.csv",
+        [
+            _egyptian_row(
+                "beans , broad (foulmedames)",
+                **{
+                    "ENERGY (Kcal)": 98,
+                    "PROTEIN (g)": 5.6,
+                    "FAT (g)": 0.7,
+                    "CARBOHYDRATE  (g)": 17.2,
+                    "FIBER (g)": 2.0,
+                    "SODIUM (mg)": 24,
+                },
+            )
+        ],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="recognized_dish",
+            recognized_dish="foulmedames",
+        )
+    )
+
+    assert result.matched_dish.name == "beans , broad (foulmedames)"
+    assert result.nutrients.calories_kcal == 98
+    assert result.source.dataset == "egyptian_food_csv"
+
+
+def test_egyptian_csv_partial_nutrients_mark_partial_quality(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(tmp_path / "nutrition.xlsx", [_base_row("Cornstarch")])
+    _write_egyptian_food_csv(
+        tmp_path / "Egyptian Food.csv",
+        [
+            _egyptian_row(
+                "beans , broad (taamia), fride",
+                **{
+                    "ENERGY (Kcal)": 355,
+                    "PROTEIN (g)": 10.9,
+                    "FAT (g)": None,
+                    "CARBOHYDRATE  (g)": 32.6,
+                    "FIBER (g)": 1.5,
+                    "SODIUM (mg)": 524,
+                },
+            )
+        ],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="recognized_dish",
+            recognized_dish="taamia",
+        )
+    )
+
+    assert result.matched_dish.name == "beans , broad (taamia), fride"
+    assert result.nutrients.fat_g is None
+    assert result.data_quality.completeness == "partial"
+    assert "One or more core nutrient values are unavailable." in (result.warnings or [])
+
+
+def test_estimate_ingredient_set_averages_matched_xlsx_foods(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(
+        tmp_path / "nutrition.xlsx",
+        [
+            _base_row("Rice", calories=120, protein="2 g", carbohydrate="25 g", fat="1 g"),
+            _base_row("Lentils", calories=180, protein="9 g", carbohydrate="30 g", fat="2 g"),
+        ],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="ingredient_set",
+            ingredients=["Rice", "Lentils"],
+        )
+    )
+
+    assert result.matched_dish.match_type == "ingredient_set"
+    assert result.serving_assumptions.basis == "100 g composite serving"
+    assert result.nutrients.calories_kcal == 150
+    assert result.nutrients.protein_g == 5.5
+    assert result.nutrients.carbohydrates_g == 27.5
+    assert result.nutrients.fat_g == 1.5
+    assert result.confidence == 0.9
+    assert result.data_quality.completeness == "complete"
+
+
+def test_recognized_dish_falls_back_to_supplied_ingredients(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(
+        tmp_path / "nutrition.xlsx",
+        [
+            _base_row("Rice", calories=120),
+            _base_row("Lentils", calories=180),
+        ],
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="recognized_dish",
+            recognized_dish="Koshari",
+            ingredients=["Rice", "Lentils"],
+        )
+    )
+
+    assert result.matched_dish.match_type == "ingredient_set"
+    assert result.nutrients.calories_kcal == 150
+    assert any("No direct nutrition match found for 'Koshari'" in warning for warning in result.warnings or [])
+
+
+def test_estimate_uses_fooddata_central_fallback(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(tmp_path / "nutrition.xlsx", [_base_row("Cornstarch")])
+    (tmp_path / FDC_FOUNDATION_JSON).write_text(
+        json.dumps(
+            {
+                "FoundationFoods": [
+                    {
+                        "fdcId": 42,
+                        "description": "Dragon fruit, raw",
+                        "foodNutrients": [
+                            {"nutrient": {"id": 1008, "name": "Energy", "unitName": "kcal"}, "amount": 60},
+                            {"nutrient": {"id": 1003, "name": "Protein", "unitName": "g"}, "amount": 1.2},
+                            {
+                                "nutrient": {
+                                    "id": 1005,
+                                    "name": "Carbohydrate, by difference",
+                                    "unitName": "g",
+                                },
+                                "amount": 13,
+                            },
+                            {
+                                "nutrient": {"id": 1004, "name": "Total lipid (fat)", "unitName": "g"},
+                                "amount": 0.4,
+                            },
+                            {
+                                "nutrient": {"id": 1093, "name": "Sodium, Na", "unitName": "mg"},
+                                "amount": 1,
+                            },
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    service = NutritionService(data_dir=tmp_path)
+
+    result = service.estimate(
+        NutritionEstimateRequest(
+            input_type="recognized_dish",
+            recognized_dish="dragon fruit",
+        )
+    )
+
+    assert result.matched_dish.name == "Dragon fruit, raw"
+    assert result.nutrients.calories_kcal == 60
+    assert result.source.dataset == "fdc_foundation"
+    assert result.source.source_type == "fooddata_central"
+    assert any("fuzzy matching" in warning for warning in result.warnings or [])
+
+
+def test_estimate_no_match_raises_not_found(tmp_path: Path) -> None:
+    _write_nutrition_xlsx(tmp_path / "nutrition.xlsx", [_base_row("Cornstarch")])
+    service = NutritionService(data_dir=tmp_path)
+
+    with pytest.raises(NotFoundError):
+        service.estimate(
+            NutritionEstimateRequest(
+                input_type="recognized_dish",
+                recognized_dish="No Such Food",
+            )
+        )
+
+
+def test_missing_nutrition_xlsx_raises_upstream_unavailable(tmp_path: Path) -> None:
+    service = NutritionService(data_dir=tmp_path)
+
+    with pytest.raises(UpstreamUnavailableError):
+        service.estimate(
+            NutritionEstimateRequest(
+                input_type="recognized_dish",
+                recognized_dish="Cornstarch",
+            )
+        )

--- a/backend/app/tests/test_v1_endpoints.py
+++ b/backend/app/tests/test_v1_endpoints.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.services.exceptions import NotFoundError, UpstreamUnavailableError
 
 
 client = TestClient(app)
@@ -18,7 +19,7 @@ def test_v1_post_endpoints_return_mock_responses() -> None:
         (
             "post",
             "/v1/nutrition/estimate",
-            {"input_type": "recognized_dish", "recognized_dish": "koshari"},
+            {"input_type": "recognized_dish", "recognized_dish": "Eggplant, raw"},
         ),
         ("post", "/v1/recipes/suggest", {"pantry_items": ["rice", "lentils"]}),
         (
@@ -115,6 +116,60 @@ def test_vision_identify_returns_structured_response(monkeypatch) -> None:
     assert body["image_id"] == "img_test_001"
     assert body["dish_candidates"][0]["name"] == "koshari"
     assert body["source"]["provider"] == "gemini"
+
+
+def test_nutrition_estimate_returns_real_xlsx_response() -> None:
+    response = client.post(
+        "/v1/nutrition/estimate",
+        json={"input_type": "recognized_dish", "recognized_dish": "Eggplant, raw"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["matched_dish"]["name"] == "Eggplant, raw"
+    assert body["source"] == {
+        "dataset": "nutrition_xlsx",
+        "source_type": "nutrition_dataset",
+    }
+    assert body["nutrients"]["calories_kcal"] == 25
+
+
+def test_nutrition_estimate_returns_404_for_no_match(monkeypatch) -> None:
+    def fake_estimate_nutrition_with_data(payload) -> None:
+        del payload
+        raise NotFoundError("not found")
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.nutrition.estimate_nutrition_with_data",
+        fake_estimate_nutrition_with_data,
+    )
+
+    response = client.post(
+        "/v1/nutrition/estimate",
+        json={"input_type": "recognized_dish", "recognized_dish": "missing food"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "NOT_FOUND"
+
+
+def test_nutrition_estimate_returns_503_for_unavailable_source(monkeypatch) -> None:
+    def fake_estimate_nutrition_with_data(payload) -> None:
+        del payload
+        raise UpstreamUnavailableError("unavailable")
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.nutrition.estimate_nutrition_with_data",
+        fake_estimate_nutrition_with_data,
+    )
+
+    response = client.post(
+        "/v1/nutrition/estimate",
+        json={"input_type": "recognized_dish", "recognized_dish": "eggplant"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "UPSTREAM_UNAVAILABLE"
 
 
 def test_v1_get_endpoints_return_mock_responses() -> None:

--- a/backend/app/tests/test_vision_service.py
+++ b/backend/app/tests/test_vision_service.py
@@ -74,6 +74,12 @@ def test_gemini_client_sends_inline_image_and_parses_structured_output() -> None
         "mime_type": "image/jpeg",
         "data": base64.b64encode(b"fake-image").decode("ascii"),
     }
+    prompt = captured["payload"]["contents"][0]["parts"][1]["text"]
+    assert "Prioritize Egyptian dishes" in prompt
+    assert "prefer 'macaroni bechamel' over 'pastitsio'" in prompt
+    assert "Use the simplest accurate food name" in prompt
+    assert "use 'walnuts' instead of 'glazed walnuts'" in prompt
+    assert "cashews' instead of 'seasoned cashews'" in prompt
     generation_config = captured["payload"]["generationConfig"]
     assert generation_config["responseMimeType"] == "application/json"
     assert generation_config["responseJsonSchema"]["required"] == [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ bcrypt==4.0.1
 python-jose[cryptography]>=3.3,<4.0
 email-validator>=2.2,<3.0
 pandas>=2.2,<3.0
+openpyxl>=3.1,<4.0
 
 # Web scraping / browser automation
 # If you install any `scrapling[...]` extras, make sure you run `scrapling install`

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2844,7 +2844,7 @@ class LoadingState extends StatelessWidget {
           child: CircularProgressIndicator(strokeWidth: 2),
         ),
         title: Text(title),
-        subtitle: const Text('Calling FastAPI stub...'),
+        subtitle: const Text('Calling FastAPI...'),
       ),
     );
   }
@@ -2924,6 +2924,7 @@ class PayloadCard extends ConsumerWidget {
     final raw = payload.raw;
     final summary = summarizePayload(raw);
     final isBarcodeScan = isBarcodeScanPayload(raw);
+    final isVisionIdentify = isVisionIdentifyPayload(raw);
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(12),
@@ -2946,6 +2947,8 @@ class PayloadCard extends ConsumerWidget {
               ),
             if (isBarcodeScan)
               BarcodeScanResultView(raw: raw)
+            else if (isVisionIdentify)
+              VisionIdentifyResultView(raw: raw)
             else
               for (final item in summary.entries)
                 Padding(
@@ -3114,6 +3117,104 @@ class BarcodeScanResultView extends StatelessWidget {
             ],
           ),
         ),
+      ],
+    );
+  }
+}
+
+class VisionIdentifyResultView extends StatelessWidget {
+  const VisionIdentifyResultView({super.key, required this.raw});
+
+  final Map<String, Object?> raw;
+
+  @override
+  Widget build(BuildContext context) {
+    final dishCandidates = visionCandidates(raw['dish_candidates']);
+    final ingredientCandidates = visionCandidates(raw['ingredients']);
+    final topCandidate = dishCandidates.isEmpty ? null : dishCandidates.first;
+    final confidence = number(raw['confidence']);
+    final warnings = textList(raw['warnings']);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          topCandidate?.name ?? 'Unknown food item',
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        if (confidence != null) ...[
+          const SizedBox(height: 2),
+          Text(
+            'Overall confidence: ${formatConfidence(confidence)}',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+        const SizedBox(height: 12),
+        const SectionHeader(title: 'Dish candidates'),
+        const SizedBox(height: 6),
+        if (dishCandidates.isEmpty)
+          Text(
+            'No reliable dish candidates returned.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          )
+        else
+          Column(
+            children: [
+              for (final candidate in dishCandidates)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          candidate.name,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                      if (candidate.confidence != null) ...[
+                        const SizedBox(width: 12),
+                        Text(
+                          formatConfidence(candidate.confidence!),
+                          textAlign: TextAlign.right,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        const SizedBox(height: 12),
+        const SectionHeader(title: 'Ingredients'),
+        const SizedBox(height: 6),
+        if (ingredientCandidates.isEmpty)
+          Text(
+            'No reliable ingredient candidates returned.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          )
+        else
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              for (final candidate in ingredientCandidates)
+                Chip(
+                  label: Text(visionCandidateChipLabel(candidate)),
+                  visualDensity: VisualDensity.compact,
+                ),
+            ],
+          ),
+        if (warnings.isNotEmpty)
+          NoticeCard(
+            icon: Icons.warning_amber_outlined,
+            title: 'Warnings',
+            message: warnings.join('\n'),
+          ),
       ],
     );
   }
@@ -3606,8 +3707,80 @@ class NutritionRow {
   final String value;
 }
 
+class VisionCandidate {
+  const VisionCandidate({required this.name, required this.confidence});
+
+  final String name;
+  final double? confidence;
+}
+
 bool isBarcodeScanPayload(Map<String, Object?> raw) {
   return raw['product_id'] != null && raw['nutrition'] is Map;
+}
+
+bool isVisionIdentifyPayload(Map<String, Object?> raw) {
+  final source = raw['source'];
+  return raw['image_id'] != null &&
+      raw['dish_candidates'] is List &&
+      raw['ingredients'] is List &&
+      source is Map &&
+      source['source_type'] == 'vision_model';
+}
+
+List<VisionCandidate> visionCandidates(Object? rawCandidates) {
+  if (rawCandidates is! List) {
+    return const [];
+  }
+
+  final candidates = <VisionCandidate>[];
+  for (final item in rawCandidates) {
+    if (item is Map) {
+      final name = text(
+        item['name'] ?? item['text'] ?? item['ingredient'],
+        fallback: '',
+      ).trim();
+      if (name.isEmpty) {
+        continue;
+      }
+      candidates.add(
+        VisionCandidate(name: name, confidence: number(item['confidence'])),
+      );
+      continue;
+    }
+
+    final name = text(item, fallback: '').trim();
+    if (name.isNotEmpty) {
+      candidates.add(VisionCandidate(name: name, confidence: null));
+    }
+  }
+  return candidates;
+}
+
+String visionCandidateChipLabel(VisionCandidate candidate) {
+  final confidence = candidate.confidence;
+  if (confidence == null) {
+    return candidate.name;
+  }
+  return '${candidate.name} ${formatConfidence(confidence)}';
+}
+
+String formatConfidence(double confidence) {
+  return '${(confidence * 100).toStringAsFixed(0)}%';
+}
+
+List<String> textList(Object? rawValues) {
+  if (rawValues is! List) {
+    return const [];
+  }
+
+  final values = <String>[];
+  for (final item in rawValues) {
+    final value = text(item, fallback: '').trim();
+    if (value.isNotEmpty) {
+      values.add(value);
+    }
+  }
+  return values;
 }
 
 String nutritionBasisDisplayLabel(Object? rawNutrition) {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1293,6 +1293,9 @@ final chatControllerProvider =
       (ref) => EndpointController(ref.read(apiClientProvider)),
     );
 
+const noReliableVisionNutritionInputMessage =
+    'No reliable nutrition input was found from this image.';
+
 class ScanScreen extends ConsumerStatefulWidget {
   const ScanScreen({super.key});
 
@@ -1305,6 +1308,7 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
   final dishController = TextEditingController(text: 'koshari');
   final ScrollController _scrollController = ScrollController();
   final GlobalKey _scanResultKey = GlobalKey();
+  Map<String, Object?>? _lastNutritionRequestBody;
 
   @override
   void initState() {
@@ -1417,12 +1421,13 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
             title: 'Scan result',
             value: scanState,
             onRetry: _lookupBarcode,
+            onEstimateNutritionFromVision: _estimateNutritionFromVision,
           ),
         ),
         AsyncPayloadView(
           title: 'Nutrition estimate',
           value: nutritionState,
-          onRetry: _estimateNutrition,
+          onRetry: _retryNutritionEstimate,
         ),
       ],
     );
@@ -1472,12 +1477,45 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
       showValidation(context, 'Recognized dish is required.');
       return;
     }
+    _submitNutritionEstimate(<String, Object?>{
+      'input_type': 'recognized_dish',
+      'recognized_dish': dish,
+    });
+  }
+
+  void _retryNutritionEstimate() {
+    final body = _lastNutritionRequestBody;
+    if (body == null) {
+      _estimateNutrition();
+      return;
+    }
+    _submitNutritionEstimate(body);
+  }
+
+  void _estimateNutritionFromVision(Map<String, Object?> raw) {
+    final body = nutritionRequestBodyFromVisionPayload(raw);
+    if (body == null) {
+      showValidation(context, noReliableVisionNutritionInputMessage);
+      return;
+    }
+
+    if (body['input_type'] == 'recognized_dish') {
+      final dish = text(body['recognized_dish'], fallback: '').trim();
+      if (dish.isNotEmpty) {
+        dishController.text = dish;
+      }
+    }
+    _submitNutritionEstimate(body);
+  }
+
+  void _submitNutritionEstimate(Map<String, Object?> body) {
+    _lastNutritionRequestBody = Map<String, Object?>.from(body);
     ref
         .read(nutritionControllerProvider.notifier)
         .run(
           (client) => client.post(
             '/v1/nutrition/estimate',
-            {'input_type': 'recognized_dish', 'recognized_dish': dish},
+            body,
             requiredFields: [
               'matched_dish',
               'nutrients',
@@ -2805,11 +2843,13 @@ class AsyncPayloadView extends ConsumerWidget {
     required this.title,
     required this.value,
     required this.onRetry,
+    this.onEstimateNutritionFromVision,
   });
 
   final String title;
   final AsyncValue<ApiPayload>? value;
   final VoidCallback onRetry;
+  final ValueChanged<Map<String, Object?>>? onEstimateNutritionFromVision;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -2818,7 +2858,11 @@ class AsyncPayloadView extends ConsumerWidget {
       return EmptyState(title: title);
     }
     return current.when(
-      data: (payload) => PayloadCard(title: title, payload: payload),
+      data: (payload) => PayloadCard(
+        title: title,
+        payload: payload,
+        onEstimateNutritionFromVision: onEstimateNutritionFromVision,
+      ),
       error: (error, stackTrace) {
         final failure = error is ApiFailure
             ? error
@@ -2913,10 +2957,16 @@ class ErrorState extends StatelessWidget {
 }
 
 class PayloadCard extends ConsumerWidget {
-  const PayloadCard({super.key, required this.title, required this.payload});
+  const PayloadCard({
+    super.key,
+    required this.title,
+    required this.payload,
+    this.onEstimateNutritionFromVision,
+  });
 
   final String title;
   final ApiPayload payload;
+  final ValueChanged<Map<String, Object?>>? onEstimateNutritionFromVision;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -2925,6 +2975,7 @@ class PayloadCard extends ConsumerWidget {
     final summary = summarizePayload(raw);
     final isBarcodeScan = isBarcodeScanPayload(raw);
     final isVisionIdentify = isVisionIdentifyPayload(raw);
+    final isNutritionEstimate = isNutritionEstimatePayload(raw);
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(12),
@@ -2948,7 +2999,12 @@ class PayloadCard extends ConsumerWidget {
             if (isBarcodeScan)
               BarcodeScanResultView(raw: raw)
             else if (isVisionIdentify)
-              VisionIdentifyResultView(raw: raw)
+              VisionIdentifyResultView(
+                raw: raw,
+                onEstimateNutrition: onEstimateNutritionFromVision,
+              )
+            else if (isNutritionEstimate)
+              NutritionEstimateResultView(raw: raw)
             else
               for (final item in summary.entries)
                 Padding(
@@ -3123,9 +3179,14 @@ class BarcodeScanResultView extends StatelessWidget {
 }
 
 class VisionIdentifyResultView extends StatelessWidget {
-  const VisionIdentifyResultView({super.key, required this.raw});
+  const VisionIdentifyResultView({
+    super.key,
+    required this.raw,
+    this.onEstimateNutrition,
+  });
 
   final Map<String, Object?> raw;
+  final ValueChanged<Map<String, Object?>>? onEstimateNutrition;
 
   @override
   Widget build(BuildContext context) {
@@ -3209,6 +3270,125 @@ class VisionIdentifyResultView extends StatelessWidget {
                 ),
             ],
           ),
+        if (onEstimateNutrition != null) ...[
+          const SizedBox(height: 12),
+          FilledButton.icon(
+            onPressed: () => onEstimateNutrition!(raw),
+            icon: const Icon(Icons.calculate_outlined),
+            label: const Text('Estimate nutrition'),
+          ),
+        ],
+        if (warnings.isNotEmpty)
+          NoticeCard(
+            icon: Icons.warning_amber_outlined,
+            title: 'Warnings',
+            message: warnings.join('\n'),
+          ),
+      ],
+    );
+  }
+}
+
+class NutritionEstimateResultView extends StatelessWidget {
+  const NutritionEstimateResultView({super.key, required this.raw});
+
+  final Map<String, Object?> raw;
+
+  @override
+  Widget build(BuildContext context) {
+    final matchedDish = raw['matched_dish'];
+    final matchedName = matchedDish is Map
+        ? text(matchedDish['name'], fallback: 'Estimated nutrition').trim()
+        : 'Estimated nutrition';
+    final matchType = matchedDish is Map
+        ? text(matchedDish['match_type'], fallback: '').trim()
+        : '';
+    final servingAssumptions = raw['serving_assumptions'];
+    final servingBasis = servingAssumptions is Map
+        ? text(servingAssumptions['basis'], fallback: '').trim()
+        : '';
+    final servingNote = servingAssumptions is Map
+        ? text(servingAssumptions['note'], fallback: '').trim()
+        : '';
+    final nutrients = nutritionEstimateRows(raw['nutrients']);
+    final confidence = number(raw['confidence']);
+    final warnings = textList(raw['warnings']);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          matchedName.isEmpty ? 'Estimated nutrition' : matchedName,
+          style: Theme.of(
+            context,
+          ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        if (matchType.isNotEmpty) ...[
+          const SizedBox(height: 2),
+          Text(
+            'Match: ${matchType.replaceAll('_', ' ')}',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+        if (confidence != null) ...[
+          const SizedBox(height: 2),
+          Text(
+            'Estimate confidence: ${formatConfidence(confidence)}',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+        const SizedBox(height: 12),
+        const SectionHeader(title: 'Estimated nutrition'),
+        const SizedBox(height: 6),
+        if (nutrients.isEmpty)
+          Text('Unavailable', style: Theme.of(context).textTheme.bodyMedium)
+        else
+          Column(
+            children: [
+              for (final row in nutrients)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          row.label,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Text(
+                        row.value,
+                        textAlign: TextAlign.right,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        if (servingBasis.isNotEmpty || servingNote.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          const SectionHeader(title: 'Serving assumption'),
+          const SizedBox(height: 6),
+          if (servingBasis.isNotEmpty)
+            Text(servingBasis, style: Theme.of(context).textTheme.bodyMedium),
+          if (servingNote.isNotEmpty) ...[
+            const SizedBox(height: 2),
+            Text(
+              servingNote,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
         if (warnings.isNotEmpty)
           NoticeCard(
             icon: Icons.warning_amber_outlined,
@@ -3714,6 +3894,13 @@ class VisionCandidate {
   final double? confidence;
 }
 
+const visionNutritionConfidenceCutoff = 0.70;
+const _unknownVisionDishNames = {
+  'unknown',
+  'unknown food',
+  'unknown food item',
+};
+
 bool isBarcodeScanPayload(Map<String, Object?> raw) {
   return raw['product_id'] != null && raw['nutrition'] is Map;
 }
@@ -3725,6 +3912,71 @@ bool isVisionIdentifyPayload(Map<String, Object?> raw) {
       raw['ingredients'] is List &&
       source is Map &&
       source['source_type'] == 'vision_model';
+}
+
+bool isNutritionEstimatePayload(Map<String, Object?> raw) {
+  return raw['matched_dish'] is Map &&
+      raw['nutrients'] is Map &&
+      raw['source'] is Map &&
+      number(raw['confidence']) != null;
+}
+
+Map<String, Object?>? nutritionRequestBodyFromVisionPayload(
+  Map<String, Object?> raw,
+) {
+  final ingredients = _distinctVisionCandidateNames(
+    visionCandidates(raw['ingredients']),
+  );
+  final dishCandidates = visionCandidates(raw['dish_candidates']);
+  if (dishCandidates.isNotEmpty) {
+    final topCandidate = dishCandidates.first;
+    final confidence = topCandidate.confidence;
+    final dishName = topCandidate.name.trim();
+    if (confidence != null &&
+        confidence >= visionNutritionConfidenceCutoff &&
+        dishName.isNotEmpty &&
+        !_isUnknownVisionDishName(dishName)) {
+      return <String, Object?>{
+        'input_type': 'recognized_dish',
+        'recognized_dish': dishName,
+        if (ingredients.isNotEmpty) 'ingredients': ingredients,
+      };
+    }
+  }
+
+  if (ingredients.isEmpty) {
+    return null;
+  }
+  return <String, Object?>{
+    'input_type': 'ingredient_set',
+    'ingredients': ingredients,
+  };
+}
+
+bool _isUnknownVisionDishName(String value) {
+  return _unknownVisionDishNames.contains(_normalizedVisionName(value));
+}
+
+String _normalizedVisionName(String value) {
+  return value.replaceAll(RegExp(r'\s+'), ' ').trim().toLowerCase();
+}
+
+List<String> _distinctVisionCandidateNames(List<VisionCandidate> candidates) {
+  final seen = <String>{};
+  final names = <String>[];
+  for (final candidate in candidates) {
+    final name = candidate.name.trim();
+    if (name.isEmpty) {
+      continue;
+    }
+    final key = _normalizedVisionName(name);
+    if (key.isEmpty || seen.contains(key)) {
+      continue;
+    }
+    seen.add(key);
+    names.add(name);
+  }
+  return names;
 }
 
 List<VisionCandidate> visionCandidates(Object? rawCandidates) {
@@ -3754,6 +4006,51 @@ List<VisionCandidate> visionCandidates(Object? rawCandidates) {
     }
   }
   return candidates;
+}
+
+List<NutritionRow> nutritionEstimateRows(Object? rawNutrients) {
+  if (rawNutrients is! Map) {
+    return const [];
+  }
+
+  final rows = <NutritionRow>[];
+  void addValue(
+    List<String> keys,
+    String label, {
+    required String unit,
+    required int decimals,
+  }) {
+    double? value;
+    for (final key in keys) {
+      value = number(rawNutrients[key]);
+      if (value != null) {
+        break;
+      }
+    }
+    if (value == null) {
+      return;
+    }
+    rows.add(
+      NutritionRow(
+        label: label,
+        value: '${formatNutritionNumber(value, decimals: decimals)} $unit',
+      ),
+    );
+  }
+
+  addValue(
+    ['calories_kcal', 'energy_kcal'],
+    'Calories',
+    unit: 'kcal',
+    decimals: 0,
+  );
+  addValue(['protein_g'], 'Protein', unit: 'g', decimals: 1);
+  addValue(['carbohydrates_g', 'carbs_g'], 'Carbs', unit: 'g', decimals: 1);
+  addValue(['fat_g'], 'Fat', unit: 'g', decimals: 1);
+  addValue(['fiber_g'], 'Fiber', unit: 'g', decimals: 1);
+  addValue(['sugar_g', 'sugars_g'], 'Sugar', unit: 'g', decimals: 1);
+  addValue(['sodium_mg'], 'Sodium', unit: 'mg', decimals: 0);
+  return rows;
 }
 
 String visionCandidateChipLabel(VisionCandidate candidate) {

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -5,6 +5,64 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:qima/main.dart';
 
 void main() {
+  test('vision nutrition request uses a high-confidence dish candidate', () {
+    final request = nutritionRequestBodyFromVisionPayload({
+      'dish_candidates': [
+        {'name': 'Koshari', 'confidence': 0.88},
+      ],
+      'ingredients': [
+        {'name': 'Rice', 'confidence': 0.92},
+      ],
+    });
+
+    expect(request, {
+      'input_type': 'recognized_dish',
+      'recognized_dish': 'Koshari',
+      'ingredients': ['Rice'],
+    });
+  });
+
+  test('vision nutrition request falls back to distinct ingredients', () {
+    final weakDishRequest = nutritionRequestBodyFromVisionPayload({
+      'dish_candidates': [
+        {'name': 'Koshari', 'confidence': 0.69},
+      ],
+      'ingredients': [
+        {'name': 'Rice', 'confidence': 0.92},
+        {'name': 'rice', 'confidence': 0.81},
+        {'name': 'Lentils', 'confidence': 0.89},
+      ],
+    });
+    final unknownDishRequest = nutritionRequestBodyFromVisionPayload({
+      'dish_candidates': [
+        {'name': 'Unknown food item', 'confidence': 0.98},
+      ],
+      'ingredients': [
+        {'name': 'Tomato', 'confidence': 0.76},
+      ],
+    });
+
+    expect(weakDishRequest, {
+      'input_type': 'ingredient_set',
+      'ingredients': ['Rice', 'Lentils'],
+    });
+    expect(unknownDishRequest, {
+      'input_type': 'ingredient_set',
+      'ingredients': ['Tomato'],
+    });
+  });
+
+  test('vision nutrition request returns null for unusable payloads', () {
+    final request = nutritionRequestBodyFromVisionPayload({
+      'dish_candidates': [
+        {'name': 'Unknown', 'confidence': 0.35},
+      ],
+      'ingredients': [],
+    });
+
+    expect(request, isNull);
+  });
+
   testWidgets('vision result card renders normalized candidates', (
     WidgetTester tester,
   ) async {
@@ -48,6 +106,7 @@ void main() {
     expect(find.text('Iceberg lettuce 99%'), findsOneWidget);
     expect(find.text('Warnings'), findsOneWidget);
     expect(find.text('Low light image'), findsOneWidget);
+    expect(find.text('Estimate nutrition'), findsNothing);
     expect(find.text('Debug payload'), findsNothing);
     expect(find.textContaining('img_test_001'), findsNothing);
   });
@@ -90,6 +149,115 @@ void main() {
     );
     expect(find.text('Uncertainty'), findsOneWidget);
     expect(find.text('Confidence is low.'), findsOneWidget);
+  });
+
+  testWidgets('vision estimate action validates unusable nutrition input', (
+    WidgetTester tester,
+  ) async {
+    var apiCalls = 0;
+
+    await tester.pumpWidget(
+      _wrap(
+        Builder(
+          builder: (context) => PayloadCard(
+            title: 'Scan result',
+            payload: ApiPayload(
+              raw: {
+                'image_id': 'img_test_003',
+                'dish_candidates': [
+                  {'name': 'Unknown food item', 'confidence': 0.32},
+                ],
+                'ingredients': [],
+                'confidence': 0.32,
+                'source': {
+                  'provider': 'gemini',
+                  'model': 'gemini_2_5_flash',
+                  'source_type': 'vision_model',
+                },
+                'data_quality': {'completeness': 'partial'},
+                'warnings': [],
+                'latency_ms': 104,
+              },
+              contractIssues: const [],
+              partialReasons: const [],
+            ),
+            onEstimateNutritionFromVision: (raw) {
+              final request = nutritionRequestBodyFromVisionPayload(raw);
+              if (request == null) {
+                showValidation(context, noReliableVisionNutritionInputMessage);
+                return;
+              }
+              apiCalls += 1;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Estimate nutrition'));
+    await tester.pump();
+
+    expect(apiCalls, 0);
+    expect(find.text(noReliableVisionNutritionInputMessage), findsOneWidget);
+  });
+
+  testWidgets('nutrition estimate card renders flat nutrient response', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        PayloadCard(
+          title: 'Nutrition estimate',
+          payload: ApiPayload(
+            raw: {
+              'matched_dish': {
+                'name': 'Koshari',
+                'match_type': 'dish',
+                'match_id': 'egy_koshari_001',
+              },
+              'serving_assumptions': {
+                'basis': '1 bowl',
+                'note': 'Estimated from default serving assumption.',
+              },
+              'nutrients': {
+                'calories_kcal': 420,
+                'protein_g': 12,
+                'carbohydrates_g': 72,
+                'fat_g': 9,
+                'fiber_g': 8,
+                'sugar_g': 6,
+                'sodium_mg': 540,
+              },
+              'confidence': 0.84,
+              'source': {
+                'dataset': 'egyptian_food_csv',
+                'source_type': 'egyptian_food_dataset',
+              },
+              'data_quality': {'completeness': 'complete'},
+              'warnings': ['Mock response. Nutrition values are estimates.'],
+            },
+            contractIssues: const [],
+            partialReasons: const [],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Nutrition estimate'), findsOneWidget);
+    expect(find.text('Koshari'), findsOneWidget);
+    expect(find.text('Match: dish'), findsOneWidget);
+    expect(find.text('Estimate confidence: 84%'), findsOneWidget);
+    expect(find.text('Serving assumption'), findsOneWidget);
+    expect(find.text('1 bowl'), findsOneWidget);
+    expect(find.text('Calories'), findsOneWidget);
+    expect(find.text('420 kcal'), findsOneWidget);
+    expect(find.text('Protein'), findsOneWidget);
+    expect(find.text('12 g'), findsOneWidget);
+    expect(find.text('Warnings'), findsOneWidget);
+    expect(
+      find.text('Mock response. Nutrition values are estimates.'),
+      findsOneWidget,
+    );
   });
 }
 

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:qima/main.dart';
+
+void main() {
+  testWidgets('vision result card renders normalized candidates', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        PayloadCard(
+          title: 'Scan result',
+          payload: ApiPayload(
+            raw: {
+              'image_id': 'img_test_001',
+              'dish_candidates': [
+                {'name': 'Iceberg lettuce', 'confidence': 0.98},
+                {'name': 'Lettuce leaf', 'confidence': 0.73},
+              ],
+              'ingredients': [
+                {'name': 'Iceberg lettuce', 'confidence': 0.99},
+              ],
+              'confidence': 0.98,
+              'source': {
+                'provider': 'gemini',
+                'model': 'gemini_2_5_flash',
+                'source_type': 'vision_model',
+              },
+              'data_quality': {'completeness': 'complete'},
+              'warnings': ['Low light image'],
+              'latency_ms': 3832,
+            },
+            contractIssues: const [],
+            partialReasons: const [],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Scan result'), findsOneWidget);
+    expect(find.text('Iceberg lettuce'), findsWidgets);
+    expect(find.text('Overall confidence: 98%'), findsOneWidget);
+    expect(find.text('Dish candidates'), findsOneWidget);
+    expect(find.text('Lettuce leaf'), findsOneWidget);
+    expect(find.text('Ingredients'), findsOneWidget);
+    expect(find.text('Iceberg lettuce 99%'), findsOneWidget);
+    expect(find.text('Warnings'), findsOneWidget);
+    expect(find.text('Low light image'), findsOneWidget);
+    expect(find.text('Debug payload'), findsNothing);
+    expect(find.textContaining('img_test_001'), findsNothing);
+  });
+
+  testWidgets('vision result card explains empty ingredient candidates', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        PayloadCard(
+          title: 'Scan result',
+          payload: ApiPayload(
+            raw: {
+              'image_id': 'img_test_002',
+              'dish_candidates': [
+                {'name': 'Unknown food item', 'confidence': 0.32},
+              ],
+              'ingredients': [],
+              'confidence': 0.32,
+              'source': {
+                'provider': 'gemini',
+                'model': 'gemini_2_5_flash',
+                'source_type': 'vision_model',
+              },
+              'data_quality': {'completeness': 'partial'},
+              'warnings': [],
+              'latency_ms': 104,
+            },
+            contractIssues: const [],
+            partialReasons: const ['Confidence is low.'],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Unknown food item'), findsWidgets);
+    expect(
+      find.text('No reliable ingredient candidates returned.'),
+      findsOneWidget,
+    );
+    expect(find.text('Uncertainty'), findsOneWidget);
+    expect(find.text('Confidence is low.'), findsOneWidget);
+  });
+}
+
+Widget _wrap(Widget child) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(body: SingleChildScrollView(child: child)),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated mobile renderer for normalized /v1/vision/identify responses
- route vision payloads separately from barcode and generic API payloads
- add widget tests for candidates, confidence, warnings, and empty ingredient fallback

## Validation
- flutter analyze lib\main.dart test\widget_test.dart
- flutter test

## Notes
- This is stacked on backend/9-gemini-vision so the PR diff stays limited to the mobile display work.